### PR TITLE
Refactor: add separate field for source-info at ObjectDetail-screen

### DIFF
--- a/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
+++ b/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
@@ -5,11 +5,11 @@ import {IOrigins} from 'core/types';
 import {useThemeStyles} from 'core/hooks';
 import {themeStyles} from './styles';
 interface IProps {
-  origins: IOrigins[] | null;
+  origins: IOrigins[];
 }
 
 export const ObjectDescriptionSource = memo(({origins}: IProps) => {
-  const styles = useThemeStyles(themeStyles, {disableStyleSheet: true});
+  const styles = useThemeStyles(themeStyles);
   const {t} = useTranslation('objectDetails');
 
   const sourceTitle = useMemo(() => {

--- a/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
+++ b/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
@@ -13,10 +13,6 @@ export const ObjectDescriptionSource = memo(({origins}: IProps) => {
   const {t} = useTranslation('objectDetails');
 
   const sourceTitle = useMemo(() => {
-    if (!origins?.length) {
-      return null;
-    }
-
     return origins.length === 1 ? t('source') : t('sources');
   }, [origins, t]);
 

--- a/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
+++ b/src/components/molecules/ObjectDescriptionSource/ObjectDescriptionSource.tsx
@@ -1,0 +1,40 @@
+import React, {memo, useMemo} from 'react';
+import {View, Text, Linking, TouchableOpacity} from 'react-native';
+import {useTranslation} from 'core/hooks';
+import {IOrigins} from 'core/types';
+import {useThemeStyles} from 'core/hooks';
+import {themeStyles} from './styles';
+interface IProps {
+  origins: IOrigins[] | null;
+}
+
+export const ObjectDescriptionSource = memo(({origins}: IProps) => {
+  const styles = useThemeStyles(themeStyles, {disableStyleSheet: true});
+  const {t} = useTranslation('objectDetails');
+
+  const sourceTitle = useMemo(() => {
+    if (!origins?.length) {
+      return null;
+    }
+
+    return origins.length === 1 ? t('source') : t('sources');
+  }, [origins, t]);
+
+  const sourceData = origins?.map(origin => {
+    return (
+      <TouchableOpacity
+        key={origin.name}
+        activeOpacity={0.8}
+        onPress={() => Linking.openURL(origin.value)}>
+        <Text style={styles.link}>{origin.name}</Text>
+      </TouchableOpacity>
+    );
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{sourceTitle}</Text>
+      {sourceData}
+    </View>
+  );
+});

--- a/src/components/molecules/ObjectDescriptionSource/index.ts
+++ b/src/components/molecules/ObjectDescriptionSource/index.ts
@@ -1,0 +1,1 @@
+export {ObjectDescriptionSource} from './ObjectDescriptionSource';

--- a/src/components/molecules/ObjectDescriptionSource/styles.ts
+++ b/src/components/molecules/ObjectDescriptionSource/styles.ts
@@ -1,6 +1,5 @@
-import {COLORS, FONTS_STYLES, FONTS} from 'assets';
+import {COLORS, FONTS_STYLES} from 'assets';
 import {PADDING_HORIZONTAL} from 'core/constants';
-export const systemFonts = Object.values(FONTS);
 
 export const themeStyles = {
   container: {

--- a/src/components/molecules/ObjectDescriptionSource/styles.ts
+++ b/src/components/molecules/ObjectDescriptionSource/styles.ts
@@ -1,0 +1,30 @@
+import {COLORS, FONTS_STYLES, FONTS} from 'assets';
+import {PADDING_HORIZONTAL} from 'core/constants';
+export const systemFonts = Object.values(FONTS);
+
+export const themeStyles = {
+  container: {
+    marginTop: 32,
+    marginHorizontal: PADDING_HORIZONTAL,
+  },
+  text: {
+    ...FONTS_STYLES.regular15,
+    color: {
+      light: COLORS.logCabin,
+      dark: COLORS.altoForDark,
+    },
+    fontStyle: 'normal',
+    textDecorationLine: 'none',
+    padding: 0,
+    margin: 0,
+  },
+
+  link: {
+    ...FONTS_STYLES.regular15,
+    color: {
+      light: COLORS.cornflowerBlue,
+      dark: COLORS.cornflowerBlue,
+    },
+    textDecorationLine: 'underline',
+  },
+};

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -4,6 +4,7 @@ export {ErrorView} from './ErrorView';
 export {ClipboardToast} from './ClipboardToast';
 export {DetailsPageCapture} from './DetailsPageCapture';
 export {ObjectDescription} from './ObjectDescription';
+export {ObjectDescriptionSource} from './ObjectDescriptionSource';
 export {ObjectInlcudesItem} from './ObjectInlcudesItem';
 export {ObjectCard} from './ObjectCard';
 export {CategoryCard} from './CategoryCard';

--- a/src/components/screens/ObjectDetails/ObjectDetails.tsx
+++ b/src/components/screens/ObjectDetails/ObjectDetails.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardToast,
   DetailsPageCapture,
   ObjectDescription,
+  ObjectDescriptionSource,
   ObjectDetailsPager,
 } from 'molecules';
 import {ObjectIncludes} from 'organisms';
@@ -166,6 +167,7 @@ export const ObjectDetails = ({route, navigation}: IProps) => {
           ) : null}
         </View>
         <ObjectDescription description={data.description} />
+        <ObjectDescriptionSource origins={data.origins} />
         {data.url ? <ObjectDetailsSiteLink url={data.url} /> : null}
         {isEmpty(data.include) ? null : (
           <ObjectIncludes

--- a/src/components/screens/ObjectDetails/ObjectDetails.tsx
+++ b/src/components/screens/ObjectDetails/ObjectDetails.tsx
@@ -167,7 +167,9 @@ export const ObjectDetails = ({route, navigation}: IProps) => {
           ) : null}
         </View>
         <ObjectDescription description={data.description} />
-        <ObjectDescriptionSource origins={data.origins} />
+        {data.origins && data.origins.length ? (
+          <ObjectDescriptionSource origins={data.origins} />
+        ) : null}
         {data.url ? <ObjectDetailsSiteLink url={data.url} /> : null}
         {isEmpty(data.include) ? null : (
           <ObjectIncludes

--- a/src/components/screens/ObjectsList/ObjectsList.tsx
+++ b/src/components/screens/ObjectsList/ObjectsList.tsx
@@ -23,11 +23,8 @@ export const ObjectsList = ({
     params: {categoryId, title, objectsIds},
   } = route;
 
-  const {
-    sendSaveCardEvent,
-    sendSelectCardEvent,
-    sendUnsaveCardEvent,
-  } = useObjectsListAnalytics();
+  const {sendSaveCardEvent, sendSelectCardEvent, sendUnsaveCardEvent} =
+    useObjectsListAnalytics();
 
   const listData = useCategoryObjects(categoryId);
 

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -48,6 +48,11 @@ export interface IObjectCategory {
   singularName: string;
 }
 
+export interface IOrigins {
+  name: string;
+  value: string;
+}
+
 export interface IObject {
   id: string;
   name: string;
@@ -63,6 +68,7 @@ export interface IObject {
   belongsTo: IBelongsTo[];
   url?: string;
   origin?: string;
+  origins: IOrigins[] | null;
   routes?: LineString;
   length: number | null;
 }

--- a/src/locale/ru.json
+++ b/src/locale/ru.json
@@ -45,7 +45,9 @@
     "actionSheetTitle": "В путь",
     "routeLength": "{{km}} км, ",
     "includes": "Чем заняться",
-    "belongs": "Входит в..."
+    "belongs": "Входит в...",
+    "source": "Источник:",
+    "sources": "Источники:"
   }, 
   "bookmarks": {
     "emptyText": "Вы пока ничего сюда не добавили"


### PR DESCRIPTION
New separate field for sources-links (under description) was created. UI keeps the same view.
Ticket-253: https://github.com/radzima-green-travel/green-travel-combine/issues/253