### PR TITLE
Fix/435 style of uibavigationbar from gradient to color fill

### DIFF
--- a/ios/greenTravel/Images.xcassets/Colors/navigationBarColor.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/navigationBarColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.231",
+          "green" : "0.659",
+          "red" : "0.294"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.243",
+          "green" : "0.216",
+          "red" : "0.157"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/utilities/Colors.h
+++ b/ios/utilities/Colors.h
@@ -20,6 +20,7 @@ NSString* UIColorToHEX(UIColor *color);
 @property (strong, nonatomic) UIColor *navigationBarTint;
 @property (strong, nonatomic) UIColor *navigationBarColorStart;
 @property (strong, nonatomic) UIColor *navigationBarColorStop;
+@property (strong, nonatomic) UIColor *navigationBarColor;
 @property (strong, nonatomic) UIColor *tabBarBackground;
 @property (strong, nonatomic) UIColor *tabBarTint;
 @property (strong, nonatomic) UIColor *cardPlaceholder;

--- a/ios/utilities/Colors.m
+++ b/ios/utilities/Colors.m
@@ -31,6 +31,7 @@ static Colors *instance;
     self.background = [UIColor colorNamed:@"background"];
     self.navigationBarTint = [UIColor colorNamed:@"navigationBarTint"];
     self.navigationBarColorStart = [UIColor colorNamed:@"navigationBarColorStart"];
+    self.navigationBarColor = [UIColor colorNamed:@"navigationBarColor"];
     self.navigationBarColorStop = [UIColor colorNamed:@"navigationBarColorStop"];
     self.tabBarBackground = [UIColor colorNamed:@"tabBarBackground"];
     self.tabBarTint = [UIColor colorNamed:@"tabBarTint"];

--- a/ios/utilities/StyleUtils.m
+++ b/ios/utilities/StyleUtils.m
@@ -13,62 +13,6 @@
 #import "TypographyLegacy.h"
 
 
-CAGradientLayer* createGradientLayer(UIView *view) {
-    CAGradientLayer *gradient = [[CAGradientLayer alloc] init];
-    gradient.frame = view.bounds;
-    gradient.colors = @[(__bridge id)[Colors get].navigationBarColorStart.CGColor,
-                        (__bridge id)[Colors get].navigationBarColorStop.CGColor];
-    gradient.startPoint = CGPointMake(0, 0);
-    gradient.endPoint = CGPointMake(1, 0);
-    return gradient;
-}
-
-CAGradientLayer* createOverlayLayer(UIView *view) {
-    if (CGRectEqualToRect(view.bounds, CGRectZero)) {
-        return nil;
-    };
-    CAGradientLayer *gradient = [[CAGradientLayer alloc] init];
-    gradient.frame = view.bounds;
-    gradient.colors = @[(__bridge id)[ColorsLegacy get].heavyMetal.CGColor, (__bridge id)UIColor.clearColor.CGColor];
-    gradient.startPoint = CGPointMake(0, 0);
-    gradient.endPoint = CGPointMake(0, 0.6);
-    return gradient;
-}
-
-void insertGradientLayer(UIView *view, CGFloat cornerRadius) {
-    CAGradientLayer *gradient = createGradientLayer(view);
-    if (cornerRadius) {
-        gradient.cornerRadius = cornerRadius;
-    }
-    if (!gradient.superlayer) {
-        [view.layer insertSublayer:gradient atIndex:0];
-    }
-}
-
-UIImage* getGradientImageToFillRectWithRadius(CGRect rect, CGFloat cornerRadius) {
-    CAGradientLayer *gradient = [[CAGradientLayer alloc] init];
-    gradient.frame = rect;
-    gradient.colors = @[(__bridge id)[Colors get].navigationBarColorStart.CGColor,
-                        (__bridge id)[Colors get].navigationBarColorStop.CGColor];
-    gradient.startPoint = CGPointMake(0, 0);
-    gradient.endPoint = CGPointMake(1, 0);
-    if (cornerRadius) {
-        gradient.cornerRadius = cornerRadius;
-    }
-    
-    UIImage* gradientImage;
-    UIGraphicsBeginImageContext(gradient.frame.size);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    [gradient renderInContext:context];
-    gradientImage = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero resizingMode:UIImageResizingModeStretch];
-    UIGraphicsEndImageContext();
-    return gradientImage;
-}
-
-UIImage* getGradientImageToFillRect(CGRect rect) {
-    return getGradientImageToFillRectWithRadius(rect, 0.0);
-}
 
 void configureNavigationBar(UINavigationBar *navigationBar) {
   CGRect navBarBounds = navigationBar.bounds;
@@ -77,7 +21,7 @@ void configureNavigationBar(UINavigationBar *navigationBar) {
   if (@available(iOS 15.0, *)) {
     UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
     [appearance configureWithOpaqueBackground];
-    appearance.backgroundImage = getGradientImageToFillRect(navBarBounds);
+    appearance.backgroundColor = [Colors get].navigationBarColor;
     appearance.backgroundEffect = nil;
     appearance.titleTextAttributes = getTextAttributes([Colors get].navigationBarTint, 16.0, UIFontWeightSemibold);
     navigationBar.standardAppearance = appearance;
@@ -85,7 +29,7 @@ void configureNavigationBar(UINavigationBar *navigationBar) {
     
   } else {
     navigationBar.titleTextAttributes = getTextAttributes([Colors get].navigationBarTint, 16.0, UIFontWeightSemibold);
-    [navigationBar setBackgroundImage:getGradientImageToFillRect(navBarBounds) forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefault];
+    navigationBar.barTintColor = [Colors get].navigationBarColor;
   }
   navigationBar.tintColor = [Colors get].navigationBarTint;
   navigationBar.barStyle = UIBarStyleDefault;


### PR DESCRIPTION
### What does this PR do:

Update navigation bar color according figma design

#### Visual change - screenshot before:
<img width="300" alt="Снимок экрана 2022-06-24 в 20 12 49" src="https://user-images.githubusercontent.com/83513326/175610024-02b1084b-f439-49d1-b3c2-624c3d7cf910.png">


#### Visual change - screenshot after
<img width="300" alt="Снимок экрана 2022-06-24 в 20 09 56" src="https://user-images.githubusercontent.com/83513326/175610059-a72722a8-333c-42e5-b002-ccdd68cd0742.png">
<img width="300" alt="Снимок экрана 2022-06-24 в 20 10 12" src="https://user-images.githubusercontent.com/83513326/175610103-f3e9e34a-9404-43e3-adab-1d52f8d63491.png">

#### Ticket Links:
#435 

#### Related PR(s):

_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._
