### PR TITLE
Fix/427 change content insets when keyboard did show

### DIFF
--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -639,6 +639,7 @@
 		6281F7E024C9E40D00C51231 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		62CDE1E12579291F00554C1E /* Montserrat-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Montserrat-Regular.ttf"; path = "../android/app/src/main/assets/fonts/Montserrat-Regular.ttf"; sourceTree = "<group>"; };
 		745C34F067A2EA32BDC236BD /* awsconfiguration.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = awsconfiguration.json; sourceTree = "<group>"; };
+		7E3231662865D12E00B39540 /* DeviceRotationObservable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeviceRotationObservable.h; sourceTree = "<group>"; };
 		90CFDA5F6334163334123761 /* Pods-greenTravel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-greenTravel.debug.xcconfig"; path = "Target Support Files/Pods-greenTravel/Pods-greenTravel.debug.xcconfig"; sourceTree = "<group>"; };
 		99067FDBAF94D93561F2FC63 /* Pods_greenTravel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_greenTravel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1E864D96B10ABCD37BAAAE8 /* Pods-greenTravel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-greenTravel.release.xcconfig"; path = "Target Support Files/Pods-greenTravel/Pods-greenTravel.release.xcconfig"; sourceTree = "<group>"; };
@@ -674,6 +675,7 @@
 				5AD347DD2837B28100235E96 /* bridges */,
 				5A775AFF26064C9000CEFC78 /* services */,
 				5A775B0B26064C9000CEFC78 /* utilities */,
+				7E3231642865D01E00B39540 /* protocols */,
 				5A775A8126064C8F00CEFC78 /* valueobjects */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				628194D025F213BD00491FDF /* BootSplash.storyboard */,
@@ -1816,6 +1818,14 @@
 				5A12E89427BEA68E004FD8C6 /* details.html */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		7E3231642865D01E00B39540 /* protocols */ = {
+			isa = PBXGroup;
+			children = (
+				7E3231662865D12E00B39540 /* DeviceRotationObservable.h */,
+			);
+			path = protocols;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {

--- a/ios/protocols/DeviceRotationObservable.h
+++ b/ios/protocols/DeviceRotationObservable.h
@@ -1,0 +1,20 @@
+//
+//  DeviceRotationObservable.h
+//  greenTravel
+//
+//  Created by Vitaly Nabarouski on 6/24/22.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@protocol DeviceRotationObservable <NSObject>
+
+- (void)addDeviceOrientationObserver;
+- (void)removeDeviceOrientationObserver;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.h
+++ b/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) UserController *userController;
 @property (strong, nonatomic) UserModel *userModel;
 @property (strong, nonatomic) UIActivityIndicatorView *loadingView;
+@property (assign, nonatomic) CGFloat tbHeight;
 
 - (instancetype)initWithController:(UserController *)controller
                    model:(UserModel *)model;

--- a/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
+++ b/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
@@ -47,11 +47,13 @@ static const CGFloat kTopOffset = 90.0;
   [super viewDidLoad];
   [self registerForKeyboardNotifications];
   [self.userModel addUserModelObserver:self];
-  
   UITapGestureRecognizer *tap =
   [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard:)];
   [self.view addGestureRecognizer:tap];
-  
+  [self prepareView];
+}
+
+- (void)prepareView {
   self.scrollView = [[UIScrollView alloc] init];
   self.scrollView.translatesAutoresizingMaskIntoConstraints = NO;
   self.scrollView.alwaysBounceVertical = YES;
@@ -158,7 +160,7 @@ static const CGFloat kTopOffset = 90.0;
 - (void)keyboardWasShown:(NSNotification*)aNotification {
   NSDictionary* info = [aNotification userInfo];
   CGSize kbSize = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
-  UIEdgeInsets contentInsets = UIEdgeInsetsMake(0.0, 0.0, kbSize.height, 0.0);
+  UIEdgeInsets contentInsets = UIEdgeInsetsMake(0.0, 0.0, kbSize.height - self.tbHeight, 0.0);
   self.scrollView.contentInset = contentInsets;
   self.scrollView.scrollIndicatorInsets = contentInsets;
 }

--- a/ios/screens/ProfileRootViewController/ProfileRootViewController.h
+++ b/ios/screens/ProfileRootViewController/ProfileRootViewController.h
@@ -7,13 +7,14 @@
 
 #import <UIKit/UIKit.h>
 #import "UserModelObserver.h"
+#import "DeviceRotationObservable.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class UserController;
 @class UserModel;
 
-@interface ProfileRootViewController : UIViewController<UserModelObserver>
+@interface ProfileRootViewController : UIViewController<UserModelObserver, DeviceRotationObservable>
 
 @property (strong, nonatomic) UserController *userController;
 @property (strong, nonatomic) UserModel *userModel;

--- a/ios/screens/ProfileRootViewController/ProfileRootViewController.m
+++ b/ios/screens/ProfileRootViewController/ProfileRootViewController.m
@@ -20,6 +20,7 @@
 @interface ProfileRootViewController ()
 
 @property (strong, nonatomic) UINavigationController *current;
+@property (strong, nonatomic) LoginViewController *loginViewController;
 
 @end
 
@@ -36,6 +37,7 @@
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
+  [self addDeviceOrientationObserver];
   configureNavigationBar(self.current.navigationBar);
 }
 
@@ -45,11 +47,34 @@
   [self onUserModelStateTransitionFrom:self.userModel.prevState toCurrentState:self.userModel.state];
 }
 
+- (void)viewDidDisappear:(BOOL)animated {
+  [super viewDidDisappear:animated];
+  [self removeDeviceOrientationObserver];
+}
+
+- (void)addDeviceOrientationObserver {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                        selector:@selector(orientationDidChange)
+                                        name:UIDeviceOrientationDidChangeNotification object:nil];
+}
+
+- (void)removeDeviceOrientationObserver {
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                        name:UIDeviceOrientationDidChangeNotification
+                                        object:nil];
+}
+
+- (void)orientationDidChange {
+  self.loginViewController.tbHeight = self.tabBarController.tabBar.frame.size.height;
+}
+
 - (void)showLoginViewController {
-  LoginViewController *loginViewController =
+  self.loginViewController =
   [[LoginViewController alloc] initWithController:self.userController
-                                                  model:self.userModel];
-  [self showViewController:loginViewController title:@"Profile"];
+                                            model:self.userModel];
+  CGFloat tabBarHeight = self.tabBarController.tabBar.frame.size.height;
+  self.loginViewController.tbHeight = tabBarHeight;
+  [self showViewController:self.loginViewController title:@"Profile"];
 }
 
 - (void)showProfileViewController {
@@ -82,7 +107,6 @@
   controllerWithNavigation.navigationBar.titleTextAttributes =
   [TypographyLegacy get].navigationSemiboldAttributes;
   
-  [self addChildViewController:controllerWithNavigation];
   controllerWithNavigation.view.frame = self.view.bounds;
   [self.view addSubview:controllerWithNavigation.view];
   [controllerWithNavigation didMoveToParentViewController:self];

--- a/ios/screens/ProfileRootViewController/ProfileRootViewController.m
+++ b/ios/screens/ProfileRootViewController/ProfileRootViewController.m
@@ -37,12 +37,12 @@
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
-  [self addDeviceOrientationObserver];
   configureNavigationBar(self.current.navigationBar);
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  [self addDeviceOrientationObserver];
   [self.userModel addUserModelObserver:self];
   [self onUserModelStateTransitionFrom:self.userModel.prevState toCurrentState:self.userModel.state];
 }
@@ -65,7 +65,9 @@
 }
 
 - (void)orientationDidChange {
-  self.loginViewController.tbHeight = self.tabBarController.tabBar.frame.size.height;
+  if (self.loginViewController != nil){
+    self.loginViewController.tbHeight = self.tabBarController.tabBar.frame.size.height;
+  }
 }
 
 - (void)showLoginViewController {


### PR DESCRIPTION
### What does this PR do:
Added observer protocol for Device orientation state. Change insets when keyboard was show. 
#### Visual change - screenshot before:

https://user-images.githubusercontent.com/66625413/176872639-35322fa2-2c64-4860-9371-16abe7549c5b.mp4

#### Visual change - screenshot after:

https://user-images.githubusercontent.com/66625413/176873141-e140fb4e-746f-4e9d-8319-5e5cd0729f78.mov

https://user-images.githubusercontent.com/66625413/176873162-e3ba1885-117b-4c7a-af0b-b62157945ab8.mov

#### Ticket Links:
https://github.com/radzima-green-travel/green-travel-combine/issues/427

#### Related PR(s):

_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._
