### PR TITLE
fix(451): add textfield background color for dark mode

### DIFF
--- a/ios/greenTravel/Images.xcassets/Colors/bottomSheetGrip.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/bottomSheetGrip.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.851",
-          "green" : "0.851",
-          "red" : "0.851"
+          "blue" : "0.741",
+          "green" : "0.741",
+          "red" : "0.741"
         }
       },
       "idiom" : "universal"

--- a/ios/greenTravel/Images.xcassets/Colors/textFieldBackground.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/textFieldBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.851",
-          "green" : "0.851",
-          "red" : "0.851"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.306",
-          "green" : "0.267",
-          "red" : "0.188"
+          "blue" : "0.184",
+          "green" : "0.157",
+          "red" : "0.102"
         }
       },
       "idiom" : "universal"

--- a/ios/greenTravel/Images.xcassets/Colors/textFieldBorderColor.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/textFieldBorderColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.851",
-          "green" : "0.851",
-          "red" : "0.851"
+          "blue" : "0.741",
+          "green" : "0.741",
+          "red" : "0.741"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.831",
-          "green" : "0.831",
-          "red" : "0.831"
+          "blue" : "0.306",
+          "green" : "0.267",
+          "red" : "0.188"
         }
       },
       "idiom" : "universal"

--- a/ios/utilities/Colors.h
+++ b/ios/utilities/Colors.h
@@ -17,6 +17,7 @@ NSString* UIColorToHEX(UIColor *color);
 @interface Colors : NSObject
 
 @property (strong, nonatomic) UIColor *background;
+@property (strong, nonatomic) UIColor *textFieldBackground;
 @property (strong, nonatomic) UIColor *navigationBarTint;
 @property (strong, nonatomic) UIColor *navigationBarColorStart;
 @property (strong, nonatomic) UIColor *navigationBarColorStop;

--- a/ios/utilities/Colors.h
+++ b/ios/utilities/Colors.h
@@ -18,6 +18,7 @@ NSString* UIColorToHEX(UIColor *color);
 
 @property (strong, nonatomic) UIColor *background;
 @property (strong, nonatomic) UIColor *textFieldBackground;
+@property (strong, nonatomic) UIColor *textFieldBorderColor;
 @property (strong, nonatomic) UIColor *navigationBarTint;
 @property (strong, nonatomic) UIColor *navigationBarColorStart;
 @property (strong, nonatomic) UIColor *navigationBarColorStop;

--- a/ios/utilities/Colors.m
+++ b/ios/utilities/Colors.m
@@ -29,6 +29,7 @@ static Colors *instance;
   self = [super init];
   if (self) {
     self.background = [UIColor colorNamed:@"background"];
+    self.textFieldBackground = [UIColor colorNamed:@"textFieldBackground"];
     self.navigationBarTint = [UIColor colorNamed:@"navigationBarTint"];
     self.navigationBarColorStart = [UIColor colorNamed:@"navigationBarColorStart"];
     self.navigationBarColor = [UIColor colorNamed:@"navigationBarColor"];

--- a/ios/utilities/Colors.m
+++ b/ios/utilities/Colors.m
@@ -30,6 +30,7 @@ static Colors *instance;
   if (self) {
     self.background = [UIColor colorNamed:@"background"];
     self.textFieldBackground = [UIColor colorNamed:@"textFieldBackground"];
+    self.textFieldBorderColor = [UIColor colorNamed:@"textFieldBorderColor"];
     self.navigationBarTint = [UIColor colorNamed:@"navigationBarTint"];
     self.navigationBarColorStart = [UIColor colorNamed:@"navigationBarColorStart"];
     self.navigationBarColor = [UIColor colorNamed:@"navigationBarColor"];

--- a/ios/views/CommonTextField/CommonTextField.m
+++ b/ios/views/CommonTextField/CommonTextField.m
@@ -29,7 +29,7 @@
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  self.backgroundColor = [Colors get].background;
+  self.backgroundColor = [Colors get].textFieldBackground;
 }
 
 - (void)setUp:(NSString *)imageName

--- a/ios/views/CommonTextField/CommonTextField.m
+++ b/ios/views/CommonTextField/CommonTextField.m
@@ -30,13 +30,13 @@
 - (void)layoutSubviews {
   [super layoutSubviews];
   self.backgroundColor = [Colors get].textFieldBackground;
+  self.layer.borderColor = [[Colors get].textFieldBorderColor CGColor];
 }
 
 - (void)setUp:(NSString *)imageName
  keyboardType:(UIKeyboardType)keyboardType
   placeholder:(NSString *)placeholder {
   self.translatesAutoresizingMaskIntoConstraints = NO;
-  self.backgroundColor = [Colors get].background;
   [NSLayoutConstraint activateConstraints:@[
     [self.heightAnchor constraintEqualToConstant:40.0],
   ]];
@@ -63,7 +63,6 @@
   ]];
   [self.textField setPlaceholder:placeholder];
   
-  self.layer.borderColor = [[Colors get].bottomSheetGrip CGColor];
   self.layer.borderWidth = 1.0;
   self.layer.cornerRadius = 2.0;
 }

--- a/ios/views/SecureTextField/SecureTextField.m
+++ b/ios/views/SecureTextField/SecureTextField.m
@@ -60,7 +60,7 @@
   ]];
   
   self.delimiterView = [[UIView alloc] initWithFrame:CGRectZero];
-  self.delimiterView.backgroundColor = [Colors get].bottomSheetGrip;
+  self.delimiterView.backgroundColor = [Colors get].textFieldBorderColor;
   
   [self addSubview:self.delimiterView];
   self.delimiterView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
### What does this PR do:

added textfield border color and background color from Figma

#### Visual change - screenshot before:
<img width="308" alt="Снимок экрана 2022-07-11 в 19 27 31" src="https://user-images.githubusercontent.com/83513326/178312372-0c4a895f-968b-44c2-9024-2bfa6e70dc79.png">


#### Visual change - screenshot after:
<img width="308" alt="Снимок экрана 2022-07-11 в 19 16 43" src="https://user-images.githubusercontent.com/83513326/178310369-62e25eeb-62a0-413c-a050-d88661c1cdfb.png">

#### Ticket Links:
#451 

#### Related PR(s):

_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._
