### PR TITLE
fix(392): bookmarks not update after adding new item

### DIFF
--- a/ios/screens/PlacesViewController/PlacesViewController.m
+++ b/ios/screens/PlacesViewController/PlacesViewController.m
@@ -372,15 +372,28 @@ didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
     }
   }
   
+  if (bookmark) {
+    if ([item.category.uuid isEqualToString:self.category.uuid]) {
+      NSUInteger indexOfAdded = [self.bookmarkedItems count];
+      NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
+      __weak typeof(self) weakSelf = self;
+      [self.collectionView performBatchUpdates:^{
+        [weakSelf.bookmarkedItems addObject:item];
+        [weakSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
+      } completion:^(BOOL finished) {
+      }];
+    }
+  }
+  
   if (!bookmark) {
-    __weak typeof(self) weakSelf = self;
-    [self.collectionView performBatchUpdates:^{
-      if (foundIndex != NSNotFound) {
+    if (foundIndex != NSNotFound) {
+      __weak typeof(self) weakSelf = self;
+      [self.collectionView performBatchUpdates:^{
         [weakSelf.bookmarkedItems removeObjectAtIndex:indexPathOfFoundIndex.item];
         [weakSelf.collectionView deleteItemsAtIndexPaths:@[indexPathOfFoundIndex]];
-      }
-    } completion:^(BOOL finished) {
-    }];
+      } completion:^(BOOL finished) {
+      }];
+    }
   }
 
   if (self.viewIfLoaded.window != nil && [self.bookmarkedItems count] == 0) {

--- a/ios/screens/PlacesViewController/PlacesViewController.m
+++ b/ios/screens/PlacesViewController/PlacesViewController.m
@@ -360,19 +360,25 @@ didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
     }
 
   if (bookmark) {
-    NSUInteger indexOfAdded = [self.bookmarkedItems count];
-    NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
+    if (item.category.uuid == _category.uuid) {
+      NSUInteger indexOfAdded = [self.bookmarkedItems count];
+      NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
+      __weak typeof(self) weakSelf = self;
+      [self.collectionView performBatchUpdates:^{
+        [weakSelf.bookmarkedItems addObject:item];
+        [weakSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
+      } completion:^(BOOL finished) {
+      }];
+    }
+  }
+  
+  if (!bookmark) {
     __weak typeof(self) weakSelf = self;
     [self.collectionView performBatchUpdates:^{
-      [weakSelf.bookmarkedItems addObject:item];
-      [weakSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
-    } completion:^(BOOL finished) {
-    }];
-  } else {
-    __weak typeof(self) weakSelf = self;
-    [self.collectionView performBatchUpdates:^{
-      [weakSelf.bookmarkedItems removeObjectAtIndex:indexPathOfFoundIndex.item];
-      [weakSelf.collectionView deleteItemsAtIndexPaths:@[indexPathOfFoundIndex]];
+      if (foundIndex != NSNotFound) {
+        [weakSelf.bookmarkedItems removeObjectAtIndex:indexPathOfFoundIndex.item];
+        [weakSelf.collectionView deleteItemsAtIndexPaths:@[indexPathOfFoundIndex]];
+      }
     } completion:^(BOOL finished) {
     }];
   }

--- a/ios/screens/PlacesViewController/PlacesViewController.m
+++ b/ios/screens/PlacesViewController/PlacesViewController.m
@@ -360,19 +360,6 @@ didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
     }
 
   if (bookmark) {
-    if (item.category.uuid == _category.uuid) {
-      NSUInteger indexOfAdded = [self.bookmarkedItems count];
-      NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
-      __weak typeof(self) weakSelf = self;
-      [self.collectionView performBatchUpdates:^{
-        [weakSelf.bookmarkedItems addObject:item];
-        [weakSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
-      } completion:^(BOOL finished) {
-      }];
-    }
-  }
-  
-  if (bookmark) {
     if ([item.category.uuid isEqualToString:self.category.uuid]) {
       NSUInteger indexOfAdded = [self.bookmarkedItems count];
       NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];

--- a/ios/screens/PlacesViewController/PlacesViewController.m
+++ b/ios/screens/PlacesViewController/PlacesViewController.m
@@ -359,28 +359,26 @@ didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
         return;
     }
 
-  if (bookmark) {
-    if ([item.category.uuid isEqualToString:self.category.uuid]) {
-      NSUInteger indexOfAdded = [self.bookmarkedItems count];
-      NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
-      __weak typeof(self) weakSelf = self;
-      [self.collectionView performBatchUpdates:^{
-        [weakSelf.bookmarkedItems addObject:item];
-        [weakSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
-      } completion:^(BOOL finished) {
-      }];
-    }
+  if (bookmark && [item.category.uuid isEqualToString:self.category.uuid]) {
+    NSUInteger indexOfAdded = [self.bookmarkedItems count];
+    NSIndexPath *indexPathOfAddedIndex = [NSIndexPath indexPathForItem:indexOfAdded inSection:0];
+    __weak typeof(self) weakSelf = self;
+    [self.collectionView performBatchUpdates:^{
+      __weak typeof(weakSelf) strongSelf = weakSelf;
+      [strongSelf.bookmarkedItems addObject:item];
+      [strongSelf.collectionView insertItemsAtIndexPaths:@[indexPathOfAddedIndex]];
+    } completion:^(BOOL finished) {
+    }];
   }
-  
-  if (!bookmark) {
-    if (foundIndex != NSNotFound) {
-      __weak typeof(self) weakSelf = self;
-      [self.collectionView performBatchUpdates:^{
-        [weakSelf.bookmarkedItems removeObjectAtIndex:indexPathOfFoundIndex.item];
-        [weakSelf.collectionView deleteItemsAtIndexPaths:@[indexPathOfFoundIndex]];
-      } completion:^(BOOL finished) {
-      }];
-    }
+
+  if (!bookmark && foundIndex != NSNotFound) {
+    __weak typeof(self) weakSelf = self;
+    [self.collectionView performBatchUpdates:^{
+      __weak typeof(weakSelf) strongSelf = weakSelf;
+      [strongSelf.bookmarkedItems removeObjectAtIndex:indexPathOfFoundIndex.item];
+      [strongSelf.collectionView deleteItemsAtIndexPaths:@[indexPathOfFoundIndex]];
+    } completion:^(BOOL finished) {
+    }];
   }
 
   if (self.viewIfLoaded.window != nil && [self.bookmarkedItems count] == 0) {


### PR DESCRIPTION
### What does this PR do:

fix the application crashes when the user tries to remove an object from favorites.
fix when you add an item to favorites, it ends up on the wrong screen.

#### Visual change - screenshot before:
#392
#469 

#### Visual change - screenshot after:

https://user-images.githubusercontent.com/83513326/180202594-da203ea8-bb90-42c5-96de-83c002b2e413.mov

#### Ticket Links:
#392 
#469 

#### Related PR(s):
_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
