### PR TITLE
fix(464): no bottom constraint for button

### DIFF
--- a/ios/screens/ProfileRootViewController/LoginViewController/CommonFormConstants.h
+++ b/ios/screens/ProfileRootViewController/LoginViewController/CommonFormConstants.h
@@ -12,3 +12,4 @@ FOUNDATION_EXPORT const CGFloat CommonFormTextFieldAndButtonSpace;
 FOUNDATION_EXPORT const CGFloat CommonFormLabelAndButtonSpace;
 FOUNDATION_EXPORT const CGFloat CommonFormMinContentInset;
 FOUNDATION_EXPORT const CGFloat CommonFormContentTopOffset;
+FOUNDATION_EXPORT const CGFloat CommonFormButtonBottomSpace;

--- a/ios/screens/ProfileRootViewController/LoginViewController/CommonFormConstants.m
+++ b/ios/screens/ProfileRootViewController/LoginViewController/CommonFormConstants.m
@@ -11,3 +11,4 @@ const CGFloat CommonFormTextFieldAndButtonSpace = 12.0;
 const CGFloat CommonFormLabelAndButtonSpace = 20.0;
 const CGFloat CommonFormMinContentInset = 23.5;
 const CGFloat CommonFormContentTopOffset = 150.0;
+const CGFloat CommonFormButtonBottomSpace = -25.0;

--- a/ios/screens/ProfileRootViewController/ResetPasswordEMailViewController/ResetPasswordEMailViewController.m
+++ b/ios/screens/ProfileRootViewController/ResetPasswordEMailViewController/ResetPasswordEMailViewController.m
@@ -91,7 +91,7 @@
     [self.buttonSubmit.topAnchor constraintEqualToAnchor:self.textFieldMail.bottomAnchor constant:CommonFormTextFieldAndButtonSpace],
     [self.buttonSubmit.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
     [self.buttonSubmit.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
-
+    [self.buttonSubmit.bottomAnchor constraintLessThanOrEqualToAnchor:self.contentView.bottomAnchor constant:CommonFormButtonBottomSpace],
   ]];
 }
 


### PR DESCRIPTION
### What does this PR do:

Adds bottom constraint to button.

#### Visual change - screenshot before:

https://user-images.githubusercontent.com/7137128/180479321-fea9b96e-8fa6-43ac-b3f8-7ca4dd938a51.mov

#### Visual change - screenshot after:

https://user-images.githubusercontent.com/7137128/180479579-d9b90e6d-009e-4950-87c0-9601933f69eb.mov

#### Ticket Links:
#464 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
