### PR TITLE
fix(464): new password screen can be scrolled

### DIFF
--- a/ios/screens/ProfileRootViewController/ResetPasswordNewPasswordViewController/ResetPasswordNewPasswordViewController.m
+++ b/ios/screens/ProfileRootViewController/ResetPasswordNewPasswordViewController/ResetPasswordNewPasswordViewController.m
@@ -92,7 +92,7 @@
     [self.buttonSubmit.topAnchor constraintEqualToAnchor:self.textFieldNewPassword.bottomAnchor constant:25.0],
     [self.buttonSubmit.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
     [self.buttonSubmit.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
-
+    [self.buttonSubmit.bottomAnchor constraintLessThanOrEqualToAnchor:self.contentView.bottomAnchor constant:CommonFormButtonBottomSpace],
   ]];
 }
 


### PR DESCRIPTION
### What does this PR do:

Lets new password screen to be scrolled in landscape mode.

#### Ticket Links:
#464 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
