### PR TITLE
fix(464): add bottom constraint for send button on request password s…

### DIFF
--- a/ios/screens/ProfileRootViewController/ResetPasswordRequestViewController/ResetPasswordRequestViewController.m
+++ b/ios/screens/ProfileRootViewController/ResetPasswordRequestViewController/ResetPasswordRequestViewController.m
@@ -79,6 +79,7 @@
     [self.buttonSubmit.topAnchor constraintEqualToAnchor:self.hintLabel.bottomAnchor constant:CommonFormLabelAndButtonSpace],
     [self.buttonSubmit.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
     [self.buttonSubmit.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
+    [self.buttonSubmit.bottomAnchor constraintLessThanOrEqualToAnchor:self.contentView.bottomAnchor constant:CommonFormButtonBottomSpace],
   ]];
 }
 


### PR DESCRIPTION
…creen

### What does this PR do:

Adds bottom constraint for send button on request password screen.

#### Ticket Links:
#464 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
