### PR TITLE
fix(504): changed localized strings for favorites tab bar title in ch…

### DIFF
--- a/ios/en.lproj/Localizable.strings
+++ b/ios/en.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 
 "TabBarMain" = "Main";
 "TabBarMap" = "Map";
-"TabBarSaved" = "Saved";
+"TabBarSaved" = "Favorites";
 "TabBarProfile" = "Profile";
 
 "IndexNewData" = "New data";

--- a/ios/zh-Hans.lproj/Localizable.strings
+++ b/ios/zh-Hans.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 
 "MapTitle" = "地图";
 
-"SavedTitle" = "收藏";
+"SavedTitle" = "最愛";
 "ProfileTitle" = "Profile";
 
 "SearchHistory" = "历史记录";

--- a/ios/zh-Hans.lproj/Localizable.strings
+++ b/ios/zh-Hans.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 
 "TabBarMain" = "主页";
 "TabBarMap" = "地图";
-"TabBarSaved" = "收藏";
+"TabBarSaved" = "最愛";
 "TabBarProfile" = "Profile";
 
 "IndexNewData" = "更新";


### PR DESCRIPTION
changed localized strings for favorites tab bar title in chinese and english

### What does this PR do:
#### Visual change - screenshot before:

<img width="331" alt="Снимок экрана 2022-08-01 в 12 02 02" src="https://user-images.githubusercontent.com/66625413/182113553-a4308fd9-9453-460e-b35e-24965dad41e5.png">

#### Visual change - screenshot after:

<img width="325" alt="Снимок экрана 2022-08-01 в 11 59 05" src="https://user-images.githubusercontent.com/66625413/182113639-82625ffd-c7b5-47d5-9305-8559dc4ec37c.png">

#### Ticket Links:

https://github.com/radzima-green-travel/green-travel-combine/issues/504

#### Related PR(s):
_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
