### PR TITLE
fix(523): changed colors of bookmarks for dark mode

### DIFF
--- a/ios/greenTravel/Images.xcassets/Colors/bookmarkDetailScreen.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/bookmarkDetailScreen.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.031",
-          "green" : "0.035",
-          "red" : "0.031"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/ios/greenTravel/Images.xcassets/Colors/bookmarkUnselectedBottomSheetTintColor.colorset/Contents.json
+++ b/ios/greenTravel/Images.xcassets/Colors/bookmarkUnselectedBottomSheetTintColor.colorset/Contents.json
@@ -20,12 +20,10 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "extended-gray",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.031",
-          "green" : "0.035",
-          "red" : "0.031"
+          "white" : "1.000"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
changed colors of bookmarks for dark mode

#### Visual change - screenshot before:

https://user-images.githubusercontent.com/66625413/182961199-3e2eda1b-7d95-469e-9e6e-c56ffeb0887f.PNG

#### Visual change - screenshot after:

https://user-images.githubusercontent.com/66625413/182961285-584dc1f5-0a9b-4a5f-9dc2-d8923b806607.png

#### Ticket Links:

https://github.com/radzima-green-travel/green-travel-combine/issues/523

#### Related PR(s):
_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
