### PR TITLE
fix: color of status bar

### DIFF
--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -25,6 +25,7 @@
     self.window.rootViewController = rootViewController;
     [self.window makeKeyAndVisible];
     [rootViewController initRNBootSplash];
+    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
     return YES;
 }
 

--- a/ios/screens/MapViewController/FullMapViewController.m
+++ b/ios/screens/MapViewController/FullMapViewController.m
@@ -104,6 +104,7 @@ static const CGFloat kClusterSize = 32.0;
                  MapViewControllerAttributionButtonInset)];
   }
   [self.navigationController setNavigationBarHidden:YES animated:YES];
+  [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDefault;
 
   [[AnalyticsEvents get] logEvent:AnalyticsEventsScreenMapFull];
 }
@@ -111,6 +112,7 @@ static const CGFloat kClusterSize = 32.0;
 - (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
   self.shouldStopSearchZoom = YES;
+  [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
### What does this PR do:

Sets color of status bar using deprecated API.
`[UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;`
See [this discussion](https://github.com/radzima-green-travel/green-travel-combine/pull/398#discussion_r939527992) as to why deprecated API is used instead of view controller based status bar style.

#### Visual change - screenshot before:
<img width="564" alt="Screenshot 2022-08-08 at 00 48 58" src="https://user-images.githubusercontent.com/7137128/183312255-67bfb3a3-bd13-4dc2-a702-f000fca08089.png">

#### Visual change - screenshot after:
<img width="564" alt="Screenshot 2022-08-08 at 00 47 26" src="https://user-images.githubusercontent.com/7137128/183312236-44f9561d-faf5-4b1f-b527-cc4b658f0136.png">

#### Ticket Links:
#410 

#### Related PR(s):
https://github.com/radzima-green-travel/green-travel-combine/pull/398

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
