### PR TITLE
fix(410): color of status bar of SFSafariViewController

### DIFF
--- a/ios/screens/DetailsViewController/DetailsViewController.m
+++ b/ios/screens/DetailsViewController/DetailsViewController.m
@@ -269,6 +269,7 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
+  [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
   [self.timeTracer traceStart];
 }
 
@@ -278,6 +279,11 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
     AnalyticsEventsParamCardName: self.item.title,
     AnalyticsEventsParamCardCategory: self.item.category.title,
   }];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
+  [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDefault;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
### What does this PR do:

Fixes color of status bar on SFSafariViewController.

#### Visual change - screenshot before:
<img width="578" alt="Screenshot 2022-08-17 at 20 24 24" src="https://user-images.githubusercontent.com/7137128/185203257-76101906-5dec-4448-8fd2-1d4e09f1df53.png">

#### Visual change - screenshot after:
<img width="578" alt="Screenshot 2022-08-17 at 20 22 39" src="https://user-images.githubusercontent.com/7137128/185203276-b0d9f457-5716-42e8-8675-f4b3e95fc0f5.png">

#### Ticket Links:
#410 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
