### PR TITLE
fix(410): color of status when popping DetailsViewController

### DIFF
--- a/ios/screens/DetailsViewController/DetailsViewController.m
+++ b/ios/screens/DetailsViewController/DetailsViewController.m
@@ -86,6 +86,7 @@
 @property (assign, nonatomic) CGFloat initialImageHeight;
 @property (assign, nonatomic) CGFloat prevContentOffsetY;
 @property (strong, nonatomic) UIImageView *currentImageView;
+@property (assign, nonatomic) BOOL showingSafariViewController;
 
 @end
 
@@ -275,6 +276,7 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
+  self.showingSafariViewController = NO;
   [[AnalyticsEvents get] logEvent:AnalyticsEventsScreenDetails withParams:@{
     AnalyticsEventsParamCardName: self.item.title,
     AnalyticsEventsParamCardCategory: self.item.category.title,
@@ -283,7 +285,9 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 - (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
-  [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDefault;
+  if (self.showingSafariViewController) {
+    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDefault;
+  }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -449,6 +453,7 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
                                              label:NSLocalizedString(@"DetailsScreenReferences", @"")
                                          cellClass:ReferenceContentTableViewCell.class
                                            onPress:^(NSObject * _Nonnull obj) {
+    weakSelf.showingSafariViewController = YES;
     InformationReference *reference = (InformationReference *) obj;
     openURL(weakSelf, reference.url);
   }];


### PR DESCRIPTION
### What does this PR do:

Fixes dark status bar style when popping DetailsViewController.

#### Visual change - screenshot before:
https://user-images.githubusercontent.com/7137128/185930370-8a88b35c-1728-423b-be62-877e1e2128b3.mp4

#### Visual change - screenshot after:
https://user-images.githubusercontent.com/7137128/185930328-03f7bb1e-7fe0-4c3b-a397-46ef30316a3a.mp4

#### Ticket Links:
#410 

#### Related PR(s):
_List any PR's that Need to be merged before this one._  
_Delete if there's no dependencies._

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
