### PR TITLE
fix(561):  сenter all button with the gap between cells

### DIFF
--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -25,7 +25,7 @@ static CGFloat kSwipeThresholdVelocity = 0.5;
 static CGFloat kDurationMax = 0.5;
 static CGFloat kDurationMin = 0.1;
 static CGFloat kRatioDivider = 1.09;
-static NSUInteger kButtonLongLength = 4;
+static CGFloat kAllButtonSize = 44.0;
 
 @interface PlacesTableViewCell ()
 
@@ -110,8 +110,8 @@ static NSUInteger kButtonLongLength = 4;
         [self.collectionView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:0.0],
     ]];
   
-  self.allButton = [[UIButton alloc] init];
-  [self.allButton setAttributedTitle:[[TypographyLegacy get]
+    self.allButton = [[UIButton alloc] init];
+    [self.allButton setAttributedTitle:[[TypographyLegacy get]
                                       makeSubtitle1Semibold:NSLocalizedString(@"IndexAll", @"")
                                       color:[Colors get].buttonAll]
                             forState:UIControlStateNormal];
@@ -122,21 +122,28 @@ static NSUInteger kButtonLongLength = 4;
     
     self.allButton.translatesAutoresizingMaskIntoConstraints = NO;
 
-    if (self.allButton.titleLabel.text.length >= kButtonLongLength) {
-      self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-      [NSLayoutConstraint activateConstraints:@[
-        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0],
+    NSMutableArray<NSLayoutConstraint *> *buttonCostraints = [@[
         [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
-        [self.allButton.heightAnchor constraintEqualToConstant:44.0],
-      ]];
+        [self.allButton.heightAnchor constraintEqualToConstant: kAllButtonSize]
+    ] mutableCopy];
+
+    NSArray<NSLayoutConstraint *> *longButtonConstraints = @[
+        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant: -16.0]
+    ];
+
+    NSArray<NSLayoutConstraint *> *shortButtonConstraints = @[
+        [self.allButton.centerXAnchor constraintEqualToAnchor:self.trailingAnchor constant: -26.0],
+        [self.allButton.widthAnchor constraintEqualToConstant: kAllButtonSize]
+    ];
+
+    if (self.allButton.titleLabel.intrinsicContentSize.width > kAllButtonSize) {
+      self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+      [buttonCostraints addObjectsFromArray:longButtonConstraints];
+      [NSLayoutConstraint activateConstraints: buttonCostraints];
     } else {
       self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
-      [NSLayoutConstraint activateConstraints:@[
-        [self.allButton.centerXAnchor constraintEqualToAnchor:self.trailingAnchor constant:-26.0],
-        [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
-                     [self.allButton.widthAnchor constraintEqualToConstant:44.0],
-        [self.allButton.heightAnchor constraintEqualToConstant:44.0],
-      ]];
+      [buttonCostraints addObjectsFromArray:shortButtonConstraints];
+      [NSLayoutConstraint activateConstraints: buttonCostraints];
     }
       
 #pragma mark - Subscribe to orientation change

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -25,7 +25,8 @@ static CGFloat kSwipeThresholdVelocity = 0.5;
 static CGFloat kDurationMax = 0.5;
 static CGFloat kDurationMin = 0.1;
 static CGFloat kRatioDivider = 1.09;
-static CGFloat kAllButtonSize = 44.0;
+static CGFloat kThresholdWidth = 44.0;
+static CGFloat kTrailingInset = -26.0;
 
 @interface PlacesTableViewCell ()
 
@@ -122,28 +123,29 @@ static CGFloat kAllButtonSize = 44.0;
     
     self.allButton.translatesAutoresizingMaskIntoConstraints = NO;
 
-    NSMutableArray<NSLayoutConstraint *> *buttonCostraints = [@[
-        [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
-        [self.allButton.heightAnchor constraintEqualToConstant: kAllButtonSize]
-    ] mutableCopy];
+    NSMutableArray<NSLayoutConstraint *> *constraints = [[NSMutableArray alloc] init];
+    [constraints addObjectsFromArray:@[
+      [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
+      [self.allButton.heightAnchor constraintEqualToConstant:kThresholdWidth]
+    ]];
 
     NSArray<NSLayoutConstraint *> *longButtonConstraints = @[
-        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant: -16.0]
+        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0]
     ];
 
     NSArray<NSLayoutConstraint *> *shortButtonConstraints = @[
-        [self.allButton.centerXAnchor constraintEqualToAnchor:self.trailingAnchor constant: -26.0],
-        [self.allButton.widthAnchor constraintEqualToConstant: kAllButtonSize]
+        [self.allButton.centerXAnchor constraintEqualToAnchor:self.trailingAnchor constant:kTrailingInset],
+        [self.allButton.widthAnchor constraintEqualToConstant:kThresholdWidth]
     ];
 
-    if (self.allButton.titleLabel.intrinsicContentSize.width > kAllButtonSize) {
+    if (self.allButton.titleLabel.intrinsicContentSize.width > kThresholdWidth) {
       self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-      [buttonCostraints addObjectsFromArray:longButtonConstraints];
-      [NSLayoutConstraint activateConstraints: buttonCostraints];
+      [constraints addObjectsFromArray:longButtonConstraints];
+      [NSLayoutConstraint activateConstraints:constraints];
     } else {
       self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
-      [buttonCostraints addObjectsFromArray:shortButtonConstraints];
-      [NSLayoutConstraint activateConstraints: buttonCostraints];
+      [constraints addObjectsFromArray:shortButtonConstraints];
+      [NSLayoutConstraint activateConstraints:constraints];
     }
       
 #pragma mark - Subscribe to orientation change

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -27,6 +27,7 @@ static CGFloat kDurationMin = 0.1;
 static CGFloat kRatioDivider = 1.09;
 static CGFloat kThresholdWidth = 44.0;
 static CGFloat kTrailingInset = -26.0;
+static CGFloat kTrailingInsetLongButton = -16.0;
 
 @interface PlacesTableViewCell ()
 
@@ -75,7 +76,7 @@ static CGFloat kTrailingInset = -26.0;
 
   self.headerLabel.attributedText = [[TypographyLegacy get] makeSubtitle1Semibold:[self.item.title uppercaseString]
                                      color:[Colors get].categoryTitleText];
-  
+
     NSUInteger safeIndex = [self indexOfMostExposedCell];
     UICollectionViewCell *cell =
     [self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForRow:safeIndex inSection:0]];
@@ -86,13 +87,13 @@ static CGFloat kTrailingInset = -26.0;
     self.headerLabel = [[UILabel alloc] init];
     [self.contentView addSubview:self.headerLabel];
     [self.headerLabel setFont:[UIFont fontWithName:@"Montserrat-SemiBold" size:14.0]];
-    
+
     self.headerLabel.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
         [self.headerLabel.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:16.0],
         [self.headerLabel.topAnchor constraintEqualToAnchor:self.topAnchor constant:24.0]
     ]];
-    
+
     UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
     [flowLayout setScrollDirection:UICollectionViewScrollDirectionHorizontal];
     self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:flowLayout];
@@ -101,7 +102,7 @@ static CGFloat kTrailingInset = -26.0;
     self.collectionView.dataSource = self;
     self.collectionView.alwaysBounceHorizontal = YES;
     self.collectionView.showsHorizontalScrollIndicator = NO;
-    
+
     [self.contentView addSubview:self.collectionView];
     self.collectionView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
@@ -110,7 +111,7 @@ static CGFloat kTrailingInset = -26.0;
         [self.collectionView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:0.0],
         [self.collectionView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:0.0],
     ]];
-  
+
     self.allButton = [[UIButton alloc] init];
     [self.allButton setAttributedTitle:[[TypographyLegacy get]
                                       makeSubtitle1Semibold:NSLocalizedString(@"IndexAll", @"")
@@ -118,9 +119,9 @@ static CGFloat kTrailingInset = -26.0;
                             forState:UIControlStateNormal];
     [self.contentView addSubview:self.allButton];
     [self.allButton.titleLabel setFont:[UIFont fontWithName:@"Montserrat-SemiBold" size:14.0]];
-    
+
     [self.allButton addTarget:self action:@selector(onAllButtonPress:) forControlEvents:UIControlEventTouchUpInside];
-    
+
     self.allButton.translatesAutoresizingMaskIntoConstraints = NO;
 
     NSMutableArray<NSLayoutConstraint *> *constraints = [[NSMutableArray alloc] init];
@@ -130,7 +131,7 @@ static CGFloat kTrailingInset = -26.0;
     ]];
 
     NSArray<NSLayoutConstraint *> *longButtonConstraints = @[
-        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0]
+        [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:kTrailingInsetLongButton]
     ];
 
     NSArray<NSLayoutConstraint *> *shortButtonConstraints = @[
@@ -147,7 +148,7 @@ static CGFloat kTrailingInset = -26.0;
       [constraints addObjectsFromArray:shortButtonConstraints];
       [NSLayoutConstraint activateConstraints:constraints];
     }
-      
+
 #pragma mark - Subscribe to orientation change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onDeviceOrientationChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
 }
@@ -213,7 +214,7 @@ static CGFloat kTrailingInset = -26.0;
         category.onPlaceCellPress();
         return;
     }
-    
+
     PlaceItem *item = self.dataSourceItems[indexPath.row];
     item.onPlaceCellPress();
 }
@@ -334,7 +335,7 @@ static const CGFloat kSpacing = 16.0;
   self.maxDragDistanceFromRight = fmax(self.collectionView.contentOffset.x -
                                        self.initialContentOffsetX,
                                        self.maxDragDistanceFromRight);
-  
+
   NSUInteger index = self.indexOfMostExposedCellBeforeDragging;
   UICollectionViewCell *cell =
   [self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]];

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -125,8 +125,8 @@ static CGFloat kTrailingInset = -26.0;
 
     NSMutableArray<NSLayoutConstraint *> *constraints = [[NSMutableArray alloc] init];
     [constraints addObjectsFromArray:@[
-      [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
-      [self.allButton.heightAnchor constraintEqualToConstant:kThresholdWidth]
+        [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
+        [self.allButton.heightAnchor constraintEqualToConstant:kThresholdWidth]
     ]];
 
     NSArray<NSLayoutConstraint *> *longButtonConstraints = @[

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -25,6 +25,7 @@ static CGFloat kSwipeThresholdVelocity = 0.5;
 static CGFloat kDurationMax = 0.5;
 static CGFloat kDurationMin = 0.1;
 static CGFloat kRatioDivider = 1.09;
+static NSUInteger kButtonLongLength = 4;
 
 @interface PlacesTableViewCell ()
 
@@ -70,11 +71,7 @@ static CGFloat kRatioDivider = 1.09;
   [super layoutSubviews];
   self.collectionView.backgroundColor = [Colors get].background;
   self.backgroundColor = [Colors get].background;
-  
-  [self.allButton setAttributedTitle:[[TypographyLegacy get]
-                                      makeSubtitle1Semibold:NSLocalizedString(@"IndexAll", @"")
-                                      color:[Colors get].buttonAll]
-                            forState:UIControlStateNormal];
+
   self.headerLabel.attributedText = [[TypographyLegacy get] makeSubtitle1Semibold:[self.item.title uppercaseString]
                                      color:[Colors get].categoryTitleText];
   
@@ -112,21 +109,36 @@ static CGFloat kRatioDivider = 1.09;
         [self.collectionView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:0.0],
         [self.collectionView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:0.0],
     ]];
-    
-    self.allButton = [[UIButton alloc] init];
+  
+  self.allButton = [[UIButton alloc] init];
+  [self.allButton setAttributedTitle:[[TypographyLegacy get]
+                                      makeSubtitle1Semibold:NSLocalizedString(@"IndexAll", @"")
+                                      color:[Colors get].buttonAll]
+                            forState:UIControlStateNormal];
     [self.contentView addSubview:self.allButton];
     [self.allButton.titleLabel setFont:[UIFont fontWithName:@"Montserrat-SemiBold" size:14.0]];
     
     [self.allButton addTarget:self action:@selector(onAllButtonPress:) forControlEvents:UIControlEventTouchUpInside];
     
     self.allButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:@[
+
+    if (self.allButton.titleLabel.text.length >= kButtonLongLength) {
+      self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+      [NSLayoutConstraint activateConstraints:@[
         [self.allButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0],
         [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
-        [self.allButton.widthAnchor constraintEqualToConstant:44.0],
         [self.allButton.heightAnchor constraintEqualToConstant:44.0],
-    ]];
-    
+      ]];
+    } else {
+      self.allButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+      [NSLayoutConstraint activateConstraints:@[
+        [self.allButton.centerXAnchor constraintEqualToAnchor:self.trailingAnchor constant:-26.0],
+        [self.allButton.centerYAnchor constraintEqualToAnchor:self.headerLabel.centerYAnchor],
+                     [self.allButton.widthAnchor constraintEqualToConstant:44.0],
+        [self.allButton.heightAnchor constraintEqualToConstant:44.0],
+      ]];
+    }
+      
 #pragma mark - Subscribe to orientation change
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onDeviceOrientationChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
 }


### PR DESCRIPTION
### What does this PR do:

Center "all" button with the gap between cells
If "all" has long text, align text to the right of screen with distance between right edge of text and right edge of screen = 16pt

#### Visual change - screenshot before:
![screen_before](https://user-images.githubusercontent.com/90133673/187205710-a6005d90-1a42-4413-8244-5ce865f778ac.png)


#### Visual change - screenshot after:
![screen_after1](https://user-images.githubusercontent.com/90133673/187205926-cd25d0a8-f03b-4938-b82a-10243cc26ee2.png)

![screen_after2](https://user-images.githubusercontent.com/90133673/187206104-2bd7a9e7-dbab-413f-8fa3-b94c10c111c5.png)


#### Ticket Links:
https://github.com/radzima-green-travel/green-travel-combine/issues/561
