### PR TITLE
fix(580): cache images for selected bookmarks

### DIFF
--- a/ios/screens/IndexViewController/PlacesTableViewCell/PhotoCollectionViewCell/PhotoCollectionViewCell.h
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PhotoCollectionViewCell/PhotoCollectionViewCell.h
@@ -15,7 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, PhotoCollectionViewCellImageType) {
   PhotoCollectionViewCellImageTypeLight = 0,
-  PhotoCollectionViewCellImageTypeDark = 1
+  PhotoCollectionViewCellImageTypeDark = 1,
+  PhotoCollectionViewCellImageTypeLightSelected = 2,
+  PhotoCollectionViewCellImageTypeDarkSelected = 3
 };
 
 @interface PhotoCollectionViewCell : UICollectionViewCell

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PhotoCollectionViewCell/PhotoCollectionViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PhotoCollectionViewCell/PhotoCollectionViewCell.m
@@ -43,7 +43,8 @@ static NSCache *imageCache = nil;
     imageCache = [NSCache new];
   }
   if ([imageCache objectForKey:@(imageType)] == nil) {
-    UIColor *color = imageType == PhotoCollectionViewCellImageTypeLight ?
+    UIColor *color = (imageType == PhotoCollectionViewCellImageTypeLight ||
+                      imageType == PhotoCollectionViewCellImageTypeLightSelected) ?
     [Colors get].bookmarkTintFullCell :
     [Colors get].bookmarkTintEmptyCell;
 
@@ -67,16 +68,22 @@ static NSCache *imageCache = nil;
   [super layoutSubviews];
   [self updateOverlayAndShadow];
   self.layer.borderColor = [[Colors get].photoCollectionViewCellBorder CGColor];
+  BOOL bookmarkSelected = self.favoritesButton.selected;
   if (self.item != nil && ![self coverIsPresent]) {
+    PhotoCollectionViewCellImageType imageType = bookmarkSelected ?
+    PhotoCollectionViewCellImageTypeDarkSelected : PhotoCollectionViewCellImageTypeDark;
     self.favoritesButton.imageView.image =
-    [PhotoCollectionViewCell imageForType:PhotoCollectionViewCellImageTypeDark
+    [PhotoCollectionViewCell imageForType:imageType
                                 baseImage:self.favoritesButton.imageView.image];
     self.headerLabel.attributedText = [[TypographyLegacy get] makeTitle2:self.item.title
                                                                    color:[Colors get].cardPlaceholderText];
     return;
   }
+  
+  PhotoCollectionViewCellImageType imageType = bookmarkSelected ?
+  PhotoCollectionViewCellImageTypeLightSelected : PhotoCollectionViewCellImageTypeLight;
   self.favoritesButton.imageView.image =
-  [PhotoCollectionViewCell imageForType:PhotoCollectionViewCellImageTypeLight
+  [PhotoCollectionViewCell imageForType:imageType
                               baseImage:self.favoritesButton.imageView.image];
 }
 


### PR DESCRIPTION
### What does this PR do:

Adds cache for images for bookmark selected states.

#### Visual change - screenshot before:
See #580 .

#### Visual change - screenshot after:


https://user-images.githubusercontent.com/7137128/190693232-f4e90bd5-9c10-4e1b-bd62-0deed28e75e2.mov


https://user-images.githubusercontent.com/7137128/190693261-e2e74369-6071-473b-8ff9-e75a5f334d52.mov


#### Ticket Links:
#580 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
