### PR TITLE
Fix/608 reset model when closing modal

### DIFF
--- a/ios/controllers/UserController/UserController.m
+++ b/ios/controllers/UserController/UserController.m
@@ -233,7 +233,21 @@
 }
 
 - (void)reset {
-  [self.model setState:UserModelStateFetched];
+  __weak typeof(self) weakSelf = self;
+  [self.authService fetchCurrentAuthSession:^(NSError * _Nullable error, BOOL signedIn) {
+    __weak typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.model setSignedIn:signedIn];
+    if (error != nil) {
+      [strongSelf.model setState:UserModelStateNotFetched];
+      return;
+    }
+    if (!signedIn) {
+      [strongSelf.model setState:UserModelStateFetched];
+      return;
+    }
+    [self fetchUserAttributesAndSetUserState:UserModelStateSignedIn
+                               fallbackState:UserModelStateFetched];
+  }];
 }
 
 @end

--- a/ios/controllers/UserController/UserController.m
+++ b/ios/controllers/UserController/UserController.m
@@ -41,16 +41,22 @@
       [strongSelf.model setState:UserModelStateNotFetched];
       return;
     }
-    [self fetchUserAttributesAndSetUserState:UserModelStateFetched];
+    if (!signedIn) {
+      [strongSelf.model setState:UserModelStateFetched];
+      return;
+    }
+    [self fetchUserAttributesAndSetUserState:UserModelStateFetched
+                               fallbackState:UserModelStateNotFetched];
   }];
 }
 
-- (void)fetchUserAttributesAndSetUserState:(UserModelState)state{
+- (void)fetchUserAttributesAndSetUserState:(UserModelState)state
+                             fallbackState:(UserModelState)fallbackState {
   __weak typeof(self) weakSelf = self;
   [self.authService fetchUserAttributes:^(NSString * _Nonnull userEmail, NSError * _Nonnull error) {
     __weak typeof(weakSelf) strongSelf = weakSelf;
     if (error != nil) {
-      [strongSelf.model setState:UserModelStateNotFetched];
+      [strongSelf.model setState:fallbackState];
       return;
     }
     [strongSelf.model setEmail:userEmail];
@@ -68,7 +74,8 @@
       [strongSelf.model setState:UserModelStateFetched];
       return;
     }
-    [self fetchUserAttributesAndSetUserState:UserModelStateSignedIn];
+    [self fetchUserAttributesAndSetUserState:UserModelStateSignedIn
+                               fallbackState:UserModelStateFetched];
   }];
 }
 


### PR DESCRIPTION
### What does this PR do:

Resets model state to either of `UserModelStateNotFetched`, `UserModelStateFetched` or `UserModelStateSignedIn` when modal is closed.

#### Ticket Links:
#608

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
