### PR TITLE
fix(606): empty email after password reset. Fixes #607

### DIFF
--- a/ios/controllers/UserController/UserController.m
+++ b/ios/controllers/UserController/UserController.m
@@ -133,7 +133,8 @@
         [strongSelf.model setError:error];
         return;
       }
-      [strongSelf.model setState:UserModelStatePasswordResetSuccess];
+      [strongSelf fetchUserAttributesAndSetUserState:UserModelStatePasswordResetSuccess
+                                       fallbackState:UserModelStateFetched];
     }];
   }];
 }


### PR DESCRIPTION
### What does this PR do:

Fixes #606 , #607 . Fetches actual email after sign in within reset password flow.

#### Ticket Links:
#606, #607.

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
