### PR TITLE
refactor(ios): silence warnings

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,18 @@
+name: SwiftLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - './ios/.swiftlint.yml'
+      - './ios/*.swift'
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: GitHub Action for SwiftLint
+        uses: norio-nomura/action-swiftlint@master
+        with:
+          args: --strict

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ amplifytools.xcconfig
 .secret-*
 **.sample
 #amplify-do-not-edit-end
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 ruby '2.7.5'
-gem 'cocoapods', '~> 1.11', '>= 1.11.2'
+gem 'cocoapods', '~> 1.11.3'
 gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,5 +97,8 @@ DEPENDENCIES
   cocoapods (~> 1.11.3)
   rexml
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
    2.2.27

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,0 +1,108 @@
+# downloaded from https://raw.githubusercontent.com/kodecocodes/swift-style-guide/main/com.raywenderlich.swiftlint.yml
+
+excluded:
+  - ${PWD}/Carthage
+  - ${PWD}/Pods
+  - ${PWD}/DerivedData
+
+disabled_rules:
+  - discarded_notification_center_observer
+  - notification_center_detachment
+  - orphaned_doc_comment
+  - todo
+  - unused_capture_list
+
+opt_in_rules:
+  - array_init
+  - attributes
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - colon # promote to error
+  - convenience_type
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - fatal_error_message
+  - first_where
+  - force_unwrapping
+  - implicitly_unwrapped_optional
+  - indentation_width
+  - last_where
+  - legacy_random
+  - literal_expression_end_indentation
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - multiline_parameters_brackets
+  - operator_usage_whitespace
+  - overridden_super_call
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - strict_fileprivate
+  - toggle_bool
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - yoda_condition
+
+analyzer_rules:
+  - unused_import
+
+custom_rules:
+  array_constructor:
+    name: 'Array/Dictionary initializer'
+    regex: '[let,var] .+ = (\[.+\]\(\))'
+    capture_group: 1
+    message: 'Use explicit type annotation when initializing empty arrays and dictionaries'
+    severity: warning
+
+attributes:
+  always_on_same_line:
+    - '@IBSegueAction'
+    - '@IBAction'
+    - '@NSManaged'
+    - '@objc'
+
+force_cast: warning
+force_try: warning
+function_body_length:
+  warning: 60
+
+legacy_hashing: error
+
+identifier_name:
+  excluded:
+    - i
+    - id
+    - x
+    - y
+    - z
+
+indentation_width:
+  indentation_width: 2
+
+line_length:
+  ignores_urls: true
+  ignores_function_declarations: true
+  ignores_comments: true
+
+multiline_arguments:
+  first_argument_location: next_line
+  only_enforce_after_first_closure_on_first_line: true
+
+private_over_fileprivate:
+  validate_extensions: true
+
+trailing_whitespace:
+  ignores_empty_lines: false
+  ignores_comments: true
+
+vertical_whitespace:
+  max_empty_lines: 2

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,6 +5,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
+inhibit_all_warnings!
+
 use_frameworks! :linkage => :static
 
 target 'greenTravel' do
@@ -17,6 +19,8 @@ target 'greenTravel' do
   
   pod 'Amplify'
   pod 'AmplifyPlugins/AWSCognitoAuthPlugin'
+
+  pod 'SwiftLint'
   
   permissions_path = '../node_modules/react-native-permissions/ios'
   pod 'Permission-LocationAlways', :path => "#{permissions_path}/LocationAlways"
@@ -67,5 +71,11 @@ target 'greenTravel' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+        config.build_settings.delete 'ARCHS'
+      end
+    end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -547,6 +547,7 @@ PODS:
   - Sentry (6.0.9):
     - Sentry/Core (= 6.0.9)
   - Sentry/Core (6.0.9)
+  - SwiftLint (0.50.3)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -618,22 +619,20 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSVG (from `../node_modules/react-native-svg`)
+  - SwiftLint
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Amplify
     - AmplifyPlugins
+    - Amplitude
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF
     - AWSCore
     - AWSMobileClient
     - AWSPluginsCore
-    - fmt
-    - libevent
-  trunk:
-    - Amplitude
     - Firebase
     - FirebaseABTesting
     - FirebaseAnalytics
@@ -643,9 +642,11 @@ SPEC REPOS:
     - FirebaseInstallations
     - FirebasePerformance
     - FirebaseRemoteConfig
+    - fmt
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
+    - libevent
     - libwebp
     - Mapbox-iOS-SDK
     - MapboxMobileEvents
@@ -654,6 +655,7 @@ SPEC REPOS:
     - SDWebImage
     - SDWebImageWebPCoder
     - Sentry
+    - SwiftLint
 
 EXTERNAL SOURCES:
   amplitude-react-native:
@@ -871,8 +873,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
   Sentry: 388c9dc093b2fd3a264466a5c5b21e25959610a9
+  SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
   Yoga: 99caf8d5ab45e9d637ee6e0174ec16fbbb01bcfc
 
-PODFILE CHECKSUM: 5b1a536eff81c2f2d8c5b6bd0f29758f2bd2f91c
+PODFILE CHECKSUM: ca1cbff5e10f8866fbfee73776a66207e77d8988
 
 COCOAPODS: 1.11.3

--- a/ios/bridges/AuthErrors.swift
+++ b/ios/bridges/AuthErrors.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// swiftlint:disable identifier_name
 @objc enum AmplifyBridgeError: Int {
   case AuthErrorFetchSessionFailed = 1
   case AuthErrorSignInFailed

--- a/ios/empty.swift
+++ b/ios/empty.swift
@@ -1,8 +1,0 @@
-//
-//  empty.swift
-//  greenTravel
-//
-//  Created by Алексей Астафьев on 7/23/20.
-//
-
-import Foundation

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0F3FCDA6FF62EE2E303ACF4F /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 5F62A26B8B4960729F8B3D98 /* amplifyconfiguration.json */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		24E15160D5632E665C362965 /* awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 745C34F067A2EA32BDC236BD /* awsconfiguration.json */; };
@@ -17,7 +16,6 @@
 		5A105EE426501FA000511256 /* RotationLockUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A105EE326501FA000511256 /* RotationLockUtility.m */; };
 		5A105FEC265FD9E300511256 /* Directions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A105FEA265FD99100511256 /* Directions.m */; };
 		5A105FF1266001AB00511256 /* MapService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A105FF0266001AB00511256 /* MapService.m */; };
-		5A1102252833FCC700FC967A /* awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A1102232833FCC600FC967A /* awsconfiguration.json */; };
 		5A1102262833FCC700FC967A /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A1102242833FCC600FC967A /* amplifyconfiguration.json */; };
 		5A12E88E27B6BFB0004FD8C6 /* ReferenceContentTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A12E88D27B6BFB0004FD8C6 /* ReferenceContentTableViewCell.m */; };
 		5A12E89027BA9A32004FD8C6 /* index-locale-legacy.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 5A12E88F27BA9A32004FD8C6 /* index-locale-legacy.graphql */; };
@@ -226,7 +224,6 @@
 		624E38D32519E4B4001D98E2 /* Montserrat-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624E38CF2519E4B4001D98E2 /* Montserrat-SemiBold.ttf */; };
 		624E38D42519E4B4001D98E2 /* Montserrat-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624E38D02519E4B4001D98E2 /* Montserrat-Bold.ttf */; };
 		628194D125F213BD00491FDF /* BootSplash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 628194D025F213BD00491FDF /* BootSplash.storyboard */; };
-		6281F7E124C9E40D00C51231 /* empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6281F7E024C9E40D00C51231 /* empty.swift */; };
 		62CDE1E22579291F00554C1E /* Montserrat-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 62CDE1E12579291F00554C1E /* Montserrat-Regular.ttf */; };
 		E11DF168135D9B2623DB17C0 /* Pods_greenTravel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99067FDBAF94D93561F2FC63 /* Pods_greenTravel.framework */; };
 /* End PBXBuildFile section */
@@ -669,7 +666,6 @@
 		624E38D02519E4B4001D98E2 /* Montserrat-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Montserrat-Bold.ttf"; path = "../android/app/src/main/assets/fonts/Montserrat-Bold.ttf"; sourceTree = "<group>"; };
 		628194D025F213BD00491FDF /* BootSplash.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = BootSplash.storyboard; path = greenTravel/BootSplash.storyboard; sourceTree = "<group>"; };
 		6281F7DF24C9E40D00C51231 /* greenTravel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "greenTravel-Bridging-Header.h"; sourceTree = "<group>"; };
-		6281F7E024C9E40D00C51231 /* empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.swift; sourceTree = "<group>"; };
 		62CDE1E12579291F00554C1E /* Montserrat-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Montserrat-Regular.ttf"; path = "../android/app/src/main/assets/fonts/Montserrat-Regular.ttf"; sourceTree = "<group>"; };
 		745C34F067A2EA32BDC236BD /* awsconfiguration.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = awsconfiguration.json; sourceTree = "<group>"; };
 		90CFDA5F6334163334123761 /* Pods-greenTravel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-greenTravel.debug.xcconfig"; path = "Target Support Files/Pods-greenTravel/Pods-greenTravel.debug.xcconfig"; sourceTree = "<group>"; };
@@ -719,7 +715,6 @@
 				5A775E7B26092B8100CEFC78 /* Settings_Debug.bundle */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				5A775E772607E0A000CEFC78 /* GreenTravel.xcdatamodeld */,
-				6281F7E024C9E40D00C51231 /* empty.swift */,
 				6281F7DF24C9E40D00C51231 /* greenTravel-Bridging-Header.h */,
 				5A39D6F126B34C04008FC20C /* Localizable.strings */,
 			);
@@ -1979,6 +1974,7 @@
 			buildPhases = (
 				456AD5FC5952504A811CAABD /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
+				79C2CCE52951B59A00855E1D /* swiftlint */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				5AD2DA2E26FDCCEC00876841 /* Add Settings.bundle */,
@@ -2005,7 +2001,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = 53APD5F9YQ;
@@ -2063,7 +2059,6 @@
 				5A775B4326064C9000CEFC78 /* Montserrat-ExtraBold.ttf in Resources */,
 				5A775B4626064C9000CEFC78 /* OpenSans-SemiBoldItalic.ttf in Resources */,
 				5A775B4226064C9000CEFC78 /* Montserrat-ExtraLightItalic.ttf in Resources */,
-				5A1102252833FCC700FC967A /* awsconfiguration.json in Resources */,
 				5A775B4D26064C9000CEFC78 /* Montserrat-ExtraBoldItalic.ttf in Resources */,
 				5A775B3C26064C9000CEFC78 /* Montserrat-MediumItalic.ttf in Resources */,
 				5AD71D9D274D5CDA00F205AD /* InfoPlist.strings in Resources */,
@@ -2081,7 +2076,6 @@
 				5A775B4826064C9000CEFC78 /* Montserrat-Italic.ttf in Resources */,
 				5A12E89027BA9A32004FD8C6 /* index-locale-legacy.graphql in Resources */,
 				24E15160D5632E665C362965 /* awsconfiguration.json in Resources */,
-				0F3FCDA6FF62EE2E303ACF4F /* amplifyconfiguration.json in Resources */,
 				5A1102262833FCC700FC967A /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2180,6 +2174,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nmkdir \"${PROJECT_DIR}/Settings.bundle/\"\nif [ \"${CONFIGURATION}\" != \"ReleaseProduction\" ]; then\ncp -R \"${PROJECT_DIR}/Settings_Debug.bundle/\" \"${PROJECT_DIR}/Settings.bundle/\"\necho \"Debug settings bundle copied\"\nfi\nif [ \"${CONFIGURATION}\" == \"ReleaseProduction\" ]; then\ncp -R \"${PROJECT_DIR}/Settings_ReleaseProduction.bundle/\" \"${PROJECT_DIR}/Settings.bundle/\"\necho \"ReleaseProduction settings bundle copied\"\nfi\n";
+		};
+		79C2CCE52951B59A00855E1D /* swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = swiftlint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which \"${PODS_ROOT}/SwiftLint/swiftlint\" > /dev/null; then\n  \"${PODS_ROOT}/SwiftLint/swiftlint\"\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		A13C2C709536C127C37EA3BF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2307,7 +2319,6 @@
 				5A6DC5D2265AAB3900A2D37B /* RoutesSheetController.m in Sources */,
 				5A775DFB26077A7D00CEFC78 /* GradientOverlayView.m in Sources */,
 				5A775E0626077A7D00CEFC78 /* FullMapViewController.m in Sources */,
-				6281F7E124C9E40D00C51231 /* empty.swift in Sources */,
 				5A95F1FB2847F39500CCA852 /* BaseFormViewController.m in Sources */,
 				5A775E0026077A7D00CEFC78 /* FilterOption.m in Sources */,
 				5A775E1026077A7D00CEFC78 /* BannerView.m in Sources */,
@@ -2490,7 +2501,7 @@
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = greenTravel/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2530,7 +2541,7 @@
 					"PB_ENABLE_MALLOC=1",
 				);
 				INFOPLIST_FILE = greenTravel/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2587,7 +2598,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -2597,6 +2608,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = ReleaseProduction;
@@ -2624,7 +2636,7 @@
 					"PB_ENABLE_MALLOC=1",
 				);
 				INFOPLIST_FILE = greenTravel/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2688,7 +2700,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -2743,7 +2755,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -2753,6 +2765,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/ios/greenTravel.xcodeproj/xcshareddata/xcschemes/greenTravel.xcscheme
+++ b/ios/greenTravel.xcodeproj/xcshareddata/xcschemes/greenTravel.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/greenTravel.xcodeproj/xcshareddata/xcschemes/greenTravelProd.xcscheme
+++ b/ios/greenTravel.xcodeproj/xcshareddata/xcschemes/greenTravelProd.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/models/BookmarksGroupModel/BookmarksGroupModel.m
+++ b/ios/models/BookmarksGroupModel/BookmarksGroupModel.m
@@ -48,6 +48,8 @@
 
 - (void)onCategoriesNewDataAvailable {}
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (void)onBookmarkUpdate:(nonnull PlaceItem *)item bookmark:(BOOL)bookmark { 
     [self fillBookmarkItemsFromCategories:self.indexModel.categories];
     [self notifyObservers];

--- a/ios/models/DetailsModel/DetailsModel.m
+++ b/ios/models/DetailsModel/DetailsModel.m
@@ -60,6 +60,8 @@
 
 - (void)onCategoriesNewDataAvailable {}
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (void)onBookmarkUpdate:(nonnull PlaceItem *)item bookmark:(BOOL)bookmark {
 }
 
@@ -96,6 +98,8 @@
         }];
     }];
 }
+
+- (void)setDetailsAllInProgress:(BOOL)inProgress {}
 
 - (void)updateDetails:(PlaceDetails * _Nullable)details
                 error:(NSError * _Nullable)error

--- a/ios/models/FeedModel/FeedModel.m
+++ b/ios/models/FeedModel/FeedModel.m
@@ -63,6 +63,8 @@
     
 }
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (NSArray<FeedItem *>*)mapCategoriesToFeedItems:(NSArray<PlaceCategory *>*)categories {
     return @[];
 }

--- a/ios/models/IndexModel/IndexModel.m
+++ b/ios/models/IndexModel/IndexModel.m
@@ -94,6 +94,8 @@ static IndexModel *instance;
     }
 }
 
+- (void)loadCategoriesRemote:(BOOL)visible {}
+
 #pragma mark - Load remote data
 - (void)loadCategoriesRemote:(BOOL)visible
                 forceRefresh:(BOOL)forceRefresh {
@@ -257,8 +259,8 @@ static IndexModel *instance;
       flatCategories[category.uuid] = category;
       if (level == 0) {
         PlaceCategory *categoryRandomized = [category copyWithZone:nil];
-        categoryRandomized.items = shuffledArray(category.items);
-        categoryRandomized.categories = slice(category.categories);
+        categoryRandomized.items = [NSMutableArray arrayWithArray:shuffledArray(category.items)];
+        categoryRandomized.categories = [NSMutableArray arrayWithArray:slice(category.categories)];
         [randomizedCategories addObject:categoryRandomized];
       }
     }

--- a/ios/models/LocationModel/LocationModel.m
+++ b/ios/models/LocationModel/LocationModel.m
@@ -18,8 +18,11 @@ static const NSUInteger kTimeWaitForLocationUpdate = 3;
 
 @end
 
-
 @implementation LocationModel
+
+@synthesize authorizationStatus;
+@synthesize delegate;
+@synthesize headingOrientation;
 
 - (instancetype)init
 {
@@ -98,5 +101,21 @@ static const NSUInteger kTimeWaitForLocationUpdate = 3;
     }
     [self notifyObservers];
 }
+
+#pragma mark - MGLLocationManager
+
+- (void)dismissHeadingCalibrationDisplay {}
+
+- (void)requestAlwaysAuthorization {}
+
+- (void)requestWhenInUseAuthorization {}
+
+- (void)startUpdatingHeading {}
+
+- (void)startUpdatingLocation {}
+
+- (void)stopUpdatingHeading {}
+
+- (void)stopUpdatingLocation {}
 
 @end

--- a/ios/models/MapModel/MapModel.m
+++ b/ios/models/MapModel/MapModel.m
@@ -64,6 +64,8 @@ static const CLLocationDistance kLocationAccuracy = 500.0;
 
 - (void)onCategoriesNewDataAvailable {}
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (void)onBookmarkUpdate:(nonnull PlaceItem *)item bookmark:(BOOL)bookmark {
 }
 

--- a/ios/models/SearchModel/SearchModel.m
+++ b/ios/models/SearchModel/SearchModel.m
@@ -60,6 +60,8 @@
 
 - (void)onCategoriesNewDataAvailable {}
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (void)onBookmarkUpdate:(nonnull PlaceItem *)item bookmark:(BOOL)bookmark {}
 
 - (void)fillSearchItemsFromCategories:(NSArray<PlaceCategory *>*)categories {

--- a/ios/screens/BookmarksViewController/BookmarksViewController.m
+++ b/ios/screens/BookmarksViewController/BookmarksViewController.m
@@ -210,7 +210,6 @@ static const CGFloat kInsetVertical = 24.0;
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-    CGSize layoutGuide = [self.view.safeAreaLayoutGuide layoutFrame].size;
     CGFloat baseWidth = self.collectionView.bounds.size.width;
     NSLog(@"Base width: %f", self.collectionView.bounds.size.width);
     NSLog(@"Bounds: %@", @(self.collectionView.bounds));

--- a/ios/screens/DetailsViewController/DetailsScreenController.m
+++ b/ios/screens/DetailsViewController/DetailsScreenController.m
@@ -11,9 +11,9 @@
 
 @end
 
-static const NSString * kDetailsTemplateName = @"details.html";
-static const NSString * kDetailsTemplateCacheKey = @"detailsTemplateId";
-NSCache<NSString *, NSMutableString *> *htmlTemplateCache;
+static NSString * const kDetailsTemplateName = @"details.html";
+static NSString * const kDetailsTemplateCacheKey = @"detailsTemplateId";
+NSCache<NSString *, NSString *> *htmlTemplateCache;
 
 NSMutableAttributedString* loadDetailsTemplate(NSString *body) {
   NSError *error;

--- a/ios/screens/DetailsViewController/DetailsViewController.m
+++ b/ios/screens/DetailsViewController/DetailsViewController.m
@@ -90,7 +90,6 @@
 
 @end
 
-static const CGFloat kDistanceDescriptionToBottom = 26.0;
 static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 @implementation DetailsViewController
@@ -601,6 +600,8 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 - (void)onCategoriesNewDataAvailable {}
 
+- (void)onDetailsLoading:(BOOL)loading {}
+
 - (void)onDetailsUpdate:(NSMutableDictionary<NSString *,PlaceDetails *> *)itemUUIDToDetails
        itemUUIDToStatus:(NSMutableDictionary<NSString *,NSNumber *> *)itemUUIDToStatus {
   PlaceDetails *details = itemUUIDToDetails[self.item.uuid];
@@ -733,7 +734,6 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 
 #pragma mark - UIScrollViewDelegate
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  CGFloat prevContentOffsetY = self.prevContentOffsetY;
   CGFloat contentOffsetY = self.dataView.contentOffset.y;
   self.prevContentOffsetY = contentOffsetY;
 

--- a/ios/screens/IndexViewController/IndexViewController.m
+++ b/ios/screens/IndexViewController/IndexViewController.m
@@ -41,14 +41,12 @@
 @property (strong, nonatomic) MapModel *mapModel;
 @property (strong, nonatomic) CoreDataService *coreDataService;
 @property (strong, nonatomic) MapService *mapService;
-@property (strong, nonatomic) NoDataView *noDataView;
 @property (strong, nonatomic) UIRefreshControl *refreshControl;
 @property (strong, nonatomic) UIView *contentView;
 @property (strong, nonatomic) UIBarButtonItem *originalBackButtonItem;
 @property (strong, nonatomic) UIImageView *placeholderImageView;
 @property (strong, nonatomic) UILabel *somethingIsWrongLabel;
 @property (strong, nonatomic) CommonButton *retryButton;
-@property (strong, nonatomic) UIActivityIndicatorView *activityIndicatorView;
 @property (strong, nonatomic) UIView *placeholder;
 @property (strong, nonatomic) RefreshButton *refreshButton;
 @property (strong, nonatomic) NSLayoutConstraint *yPosition;
@@ -60,7 +58,6 @@
 
 static NSString * const kCollectionCellId = @"collectionCellId";
 static CGFloat kDeltaCoverAndBounds = 50.0;
-static CGFloat kMinHeightOfPlaceholderView = 500.0;
 static CGFloat kNewDataButtonOffScreenOffsetY = 0.0;
 static CGFloat kNewDataButtonOnScreenOffsetY = 50.0;
 
@@ -286,6 +283,8 @@ static CGFloat kNewDataButtonOnScreenOffsetY = 50.0;
         });
     }
 }
+
+- (void)onDetailsLoading:(BOOL)loading {}
 
 #pragma mark - Bookmarks update
 - (void)onBookmarkUpdate:(nonnull PlaceItem *)item bookmark:(BOOL)bookmark {

--- a/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
+++ b/ios/screens/IndexViewController/PlacesTableViewCell/PlacesTableViewCell.m
@@ -76,10 +76,6 @@ static CGFloat kTrailingInsetLongButton = -16.0;
 
   self.headerLabel.attributedText = [[TypographyLegacy get] makeSubtitle1Semibold:[self.item.title uppercaseString]
                                      color:[Colors get].categoryTitleText];
-
-    NSUInteger safeIndex = [self indexOfMostExposedCell];
-    UICollectionViewCell *cell =
-    [self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForRow:safeIndex inSection:0]];
 }
 
 - (void)setUp {

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -218,7 +218,7 @@ static BOOL kSignUpEnabled = YES;
 }
 
 UITabBarItem* createTabBarItem(NSString *title, NSUInteger tag, UIImage *image,
-                               const NSString * _Nonnull accessibilityIdentifier) {
+                               NSString * const _Nonnull accessibilityIdentifier) {
     UITabBarItem *tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:image tag:tag];
     [tabBarItem setTitleTextAttributes:[TypographyLegacy get].tabBarSelectedAttributes
                                        forState:UIControlStateSelected];

--- a/ios/screens/MapViewController/BottomSheetViewDetailedMap/BottomSheetViewDetailedMap.m
+++ b/ios/screens/MapViewController/BottomSheetViewDetailedMap/BottomSheetViewDetailedMap.m
@@ -66,4 +66,6 @@
   [self.detailsButton setLabel:NSLocalizedString(@"ButtonBuildRouteLabel", @"")];
 }
 
+- (void)onNavigationPress {}
+
 @end

--- a/ios/screens/MapViewController/CategoriesFilterView/CategoriesFilterModel/CategoriesFilterModel.m
+++ b/ios/screens/MapViewController/CategoriesFilterView/CategoriesFilterModel/CategoriesFilterModel.m
@@ -37,7 +37,7 @@
         self.selectedCategoryUUIDs = [[NSMutableSet alloc] init];
         self.categoryUUIDs = [[NSMutableSet alloc] init];
         self.filterOptions = [[NSMutableArray alloc] init];
-        self.categoriesFilterObservers = [[NSMutableArray alloc] init];
+        self.categoriesFilterObservers = (NSMutableArray<CategoriesFilterObserver> *)[[NSMutableArray alloc] init];
         [self fillFilterOptionsFromCategories];
     }
     return self;
@@ -53,6 +53,8 @@
 - (void)onCategoriesUpdate:(nonnull NSArray<PlaceCategory *> *)categories {
     
 }
+
+- (void)onDetailsLoading:(BOOL)loading {}
 
 - (void)onMapItemsUpdate:(nonnull NSArray<MapItem *> *)mapItems {
     [self fillFilterOptionsFromCategories];

--- a/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
+++ b/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
@@ -22,8 +22,6 @@
 @end
 
 static const CGFloat kMinContentInset = 23.5;
-static const CGFloat kMaxContentWidth = 328.0;
-static const CGFloat kTopOffset = 90.0;
 
 @implementation BaseFormViewController
 
@@ -182,5 +180,7 @@ static const CGFloat kTopOffset = 90.0;
   textField.text = [textField.text stringByTrimmingCharactersInSet:
                [NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
+
+- (void)onUserStateUpdate:(nonnull UserState *)emailSendingState {}
 
 @end

--- a/ios/screens/ProfileRootViewController/LoginViewController/SignInFormView/SignInFormView.m
+++ b/ios/screens/ProfileRootViewController/LoginViewController/SignInFormView/SignInFormView.m
@@ -13,7 +13,7 @@
 #import "UIButtonHighlightable.h"
 #import "Typography.h"
 
-@interface SignInFormView()
+@interface SignInFormView() <UITextFieldDelegate>
 
 @property (strong, nonatomic) UILabel *titleLabel;
 @property (strong, nonatomic) UIButtonHighlightable *forgotPasswordButton;

--- a/ios/screens/RootViewController/RootViewController.m
+++ b/ios/screens/RootViewController/RootViewController.m
@@ -118,6 +118,8 @@
   self.current = mainViewController;
 }
 
+- (void)showRNViewController {}
+
 - (void)saveVersion {
   __weak typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
@@ -131,5 +133,7 @@
     [(MainViewController *) self.current loadCategories];
   }
 }
+
+- (void)initRNBootSplash {}
 
 @end

--- a/ios/services/ApiService/ApiServiceIndexFileLegacy.m
+++ b/ios/services/ApiService/ApiServiceIndexFileLegacy.m
@@ -66,7 +66,7 @@ static NSString * const kGetDetailsBaseURL = @"http://ecsc00a0916b.epam.com:3001
     }
     NSLog(@"Error when loading categories: %@", error);
     NSArray<PlaceCategory *> *mappedCategories = [[weakSelf mapCategoriesFromJSON:categories] copy];
-    indexModelData.categoryTree = mappedCategories;
+    indexModelData.categoryTree = [NSMutableArray arrayWithArray:mappedCategories];
     completion(indexModelData, @[], updatedHash);
   }];
   [task resume];
@@ -76,8 +76,8 @@ static NSString * const kGetDetailsBaseURL = @"http://ecsc00a0916b.epam.com:3001
   NSMutableArray<PlaceCategory *> *mappedCategories = [[NSMutableArray alloc] init];
   [categories enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     PlaceCategory *category = [[PlaceCategory alloc] init];
-    category.categories = [self mapCategoriesFromJSON:obj[@"children"]];
-    category.items = [self mapItemsFromJSON:obj[@"objects"] category:category];
+    category.categories = [NSMutableArray arrayWithArray:[self mapCategoriesFromJSON:obj[@"children"]]];
+    category.items = [NSMutableArray arrayWithArray:[self mapItemsFromJSON:obj[@"objects"] category:category]];
     if ([self categoryIsValid:category rawCategory:obj]) {
       category.title = obj[@"name"];
       category.cover = getFullImageURL(obj[@"cover"]);
@@ -187,7 +187,7 @@ NSMutableArray* categoryIdToItemsFromJSON(NSObject *relations) {
     NSArray<NSString *> *linkedItemIds = [obj[@"objects"] copy];
     CategoryUUIDToRelatedItemUUIDs *categoryUUIDToRelatedItemUUIDs = [[CategoryUUIDToRelatedItemUUIDs alloc] init];
     categoryUUIDToRelatedItemUUIDs.categoryUUID = categoryId;
-    categoryUUIDToRelatedItemUUIDs.relatedItemUUIDs = [[NSOrderedSet alloc] initWithArray:linkedItemIds];
+    categoryUUIDToRelatedItemUUIDs.relatedItemUUIDs = [[NSMutableOrderedSet alloc] initWithArray:linkedItemIds];
     [categoryIdToItems addObject:categoryUUIDToRelatedItemUUIDs];
   }];
   return categoryIdToItems;
@@ -213,7 +213,7 @@ NSMutableArray* categoryIdToItemsFromJSON(NSObject *relations) {
             NSArray<NSString *> *linkedItemIds = [obj[1] copy];
             CategoryUUIDToRelatedItemUUIDs *categoryUUIDToRelatedItemUUIDs = [[CategoryUUIDToRelatedItemUUIDs alloc] init];
             categoryUUIDToRelatedItemUUIDs.categoryUUID = categoryId;
-            categoryUUIDToRelatedItemUUIDs.relatedItemUUIDs = [[NSOrderedSet alloc] initWithArray:linkedItemIds];
+            categoryUUIDToRelatedItemUUIDs.relatedItemUUIDs = [[NSMutableOrderedSet alloc] initWithArray:linkedItemIds];
             [categoryIdToItems addObject:categoryUUIDToRelatedItemUUIDs];
         }];
         parsedDetails.categoryIdToItems = categoryIdToItems;

--- a/ios/services/ApiService/GraphQLApiService.m
+++ b/ios/services/ApiService/GraphQLApiService.m
@@ -20,9 +20,9 @@
 
 @end
 
-static const NSString * kQueryGetTag = @"index-tag";
-static const NSString * kQueryGetIndexLocaleAny = @"index-locale-any";
-static const NSString * kQueryGetIndexLocaleLegacy = @"index-locale-legacy";
+static NSString * const kQueryGetTag = @"index-tag";
+static NSString * const kQueryGetIndexLocaleAny = @"index-locale-any";
+static NSString * const kQueryGetIndexLocaleLegacy = @"index-locale-legacy";
 
 @implementation GraphQLApiService
 

--- a/ios/services/UserDefaultsService/UserDefaultsServiceConstants.h
+++ b/ios/services/UserDefaultsService/UserDefaultsServiceConstants.h
@@ -13,6 +13,6 @@
 
 #import <Foundation/Foundation.h>
 
-FOUNDATION_EXPORT const NSString * UserDefaultsServiceConstantsFrameworkRandom;
-FOUNDATION_EXPORT const NSString * UserDefaultsServiceConstantsFrameworkReact;
-FOUNDATION_EXPORT const NSString * UserDefaultsServiceConstantsFrameworkUIKit;
+FOUNDATION_EXPORT NSString * const UserDefaultsServiceConstantsFrameworkRandom;
+FOUNDATION_EXPORT NSString * const UserDefaultsServiceConstantsFrameworkReact;
+FOUNDATION_EXPORT NSString * const UserDefaultsServiceConstantsFrameworkUIKit;

--- a/ios/services/UserDefaultsService/UserDefaultsServiceConstants.m
+++ b/ios/services/UserDefaultsService/UserDefaultsServiceConstants.m
@@ -7,6 +7,6 @@
 
 #import "UserDefaultsServiceConstants.h"
 
-const NSString * UserDefaultsServiceConstantsFrameworkRandom = @"random";
-const NSString * UserDefaultsServiceConstantsFrameworkReact = @"react";
-const NSString * UserDefaultsServiceConstantsFrameworkUIKit = @"uikit";
+NSString * const UserDefaultsServiceConstantsFrameworkRandom = @"random";
+NSString * const UserDefaultsServiceConstantsFrameworkReact = @"react";
+NSString * const UserDefaultsServiceConstantsFrameworkUIKit = @"uikit";

--- a/ios/utilities/AccessibilityIdentifiers.h
+++ b/ios/utilities/AccessibilityIdentifiers.h
@@ -9,10 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT const NSString* AccessibilityIdentifiersTabBarMain;
-FOUNDATION_EXPORT const NSString* AccessibilityIdentifiersTabBarMap;
-FOUNDATION_EXPORT const NSString* AccessibilityIdentifiersTabBarFavorites;
-FOUNDATION_EXPORT const NSString* AccessibilityIdentifiersTabBarProfile;
-
+FOUNDATION_EXPORT NSString * const AccessibilityIdentifiersTabBarMain;
+FOUNDATION_EXPORT NSString * const AccessibilityIdentifiersTabBarMap;
+FOUNDATION_EXPORT NSString * const AccessibilityIdentifiersTabBarFavorites;
+FOUNDATION_EXPORT NSString * const AccessibilityIdentifiersTabBarProfile;
 
 NS_ASSUME_NONNULL_END

--- a/ios/utilities/AccessibilityIdentifiers.m
+++ b/ios/utilities/AccessibilityIdentifiers.m
@@ -7,8 +7,7 @@
 
 #import "AccessibilityIdentifiers.h"
 
-const NSString* AccessibilityIdentifiersTabBarMain = @"tabBarItemMain";
-const NSString* AccessibilityIdentifiersTabBarMap = @"tabBarItemMap";
-const NSString* AccessibilityIdentifiersTabBarFavorites = @"tabBarItemFavorites";
-const NSString* AccessibilityIdentifiersTabBarProfile = @"tabBarItemProfile";
-
+NSString * const AccessibilityIdentifiersTabBarMain = @"tabBarItemMain";
+NSString * const AccessibilityIdentifiersTabBarMap = @"tabBarItemMap";
+NSString * const AccessibilityIdentifiersTabBarFavorites = @"tabBarItemFavorites";
+NSString * const AccessibilityIdentifiersTabBarProfile = @"tabBarItemProfile";

--- a/ios/utilities/AnalyticsEvents.h
+++ b/ios/utilities/AnalyticsEvents.h
@@ -18,68 +18,68 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsUserPropertyFramework;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsUserPropertyFramework;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsNaviMain;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsNaviMap;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsNaviBookmarks;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsNaviMain;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsNaviMap;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsNaviBookmarks;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsScreenHome;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsScreenMapItem;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsScreenBookmarks;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsScreenMapFull;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsScreenDetails;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamCardName;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamCardCategory;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsScreenHome;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsScreenMapItem;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsScreenBookmarks;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsScreenMapFull;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsScreenDetails;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamCardName;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamCardCategory;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsPressCard;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsSaveCard;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsUnsaveCard;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsSeeAll;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsPressCard;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsSaveCard;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsUnsaveCard;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsSeeAll;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsPressSavedCategory;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsPressCardSaved;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamCategoryName;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsPressSavedCategory;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsPressCardSaved;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamCategoryName;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsSearchType;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsPressSearchResult;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamSearchQuery;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsSearchType;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsPressSearchResult;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamSearchQuery;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsTimeSpentInActiveState;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsTimeSpentInActiveState;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsDetailsSave;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsDetailsUnsave;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsDetailsOpenMap;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsDetailsScrollToEnd;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsPressCoords;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsDetailsBack;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamLinkType;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsDetailsSave;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsDetailsUnsave;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsDetailsOpenMap;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsDetailsScrollToEnd;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsPressCoords;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsDetailsBack;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamLinkType;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterAll;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterTerritories;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterArchitecture;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterReligion;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterNature;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterMuseums;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterWarMemorials;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterOther;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterFoot;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterBike;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapFilterWater;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterAll;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterTerritories;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterArchitecture;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterReligion;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterNature;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterMuseums;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterWarMemorials;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterOther;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterFoot;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterBike;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapFilterWater;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapSearch;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapInteraction;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamMapInteractionSave;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamMapInteractionLearnMore;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapSearchType;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsMapPressSearchResult;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamMapFilterCheck;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapSearch;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapInteraction;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamMapInteractionSave;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamMapInteractionLearnMore;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapSearchType;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsMapPressSearchResult;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamMapFilterCheck;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsLifeTimeHomeScreen;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsLifeTimeDetailsScreen;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsLifeTimeFullMapScreen;
-FOUNDATION_EXPORT const NSString* AnalyticsEventsParamTimeInterval;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsLifeTimeHomeScreen;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsLifeTimeDetailsScreen;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsLifeTimeFullMapScreen;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsParamTimeInterval;
 
-FOUNDATION_EXPORT const NSString* AnalyticsEventsGalleryPictureView;
+FOUNDATION_EXPORT NSString * const AnalyticsEventsGalleryPictureView;
 
 NS_ASSUME_NONNULL_END

--- a/ios/utilities/AnalyticsEvents.m
+++ b/ios/utilities/AnalyticsEvents.m
@@ -47,71 +47,68 @@ static AnalyticsEvents *instance;
 
 @end
 
-const NSString* AnalyticsEventsUserPropertyFramework = @"user_property_framework";
+NSString * const AnalyticsEventsUserPropertyFramework = @"user_property_framework";
 
-const NSString* AnalyticsEventsNaviMain = @"navi_home_event";
-const NSString* AnalyticsEventsNaviMap = @"navi_map_event";
-const NSString* AnalyticsEventsNaviBookmarks = @"navi_bookmarks_event";
-const NSString* AnalyticsEventsNaviProfile = @"navi_profile_event";
+NSString * const AnalyticsEventsNaviMain = @"navi_home_event";
+NSString * const AnalyticsEventsNaviMap = @"navi_map_event";
+NSString * const AnalyticsEventsNaviBookmarks = @"navi_bookmarks_event";
+NSString * const AnalyticsEventsNaviProfile = @"navi_profile_event";
 
-const NSString* AnalyticsEventsScreenHome = @"view_home_event";
-const NSString* AnalyticsEventsScreenBookmarks = @"view_bookmarks_event";
-const NSString* AnalyticsEventsScreenMapFull = @"view_map_event";
-const NSString* AnalyticsEventsScreenDetails = @"view_details_event";
-const NSString* AnalyticsEventsScreenMapItem = @"screen_map_feed_event";
-const NSString* AnalyticsEventsParamCardName = @"param_card_name";
-const NSString* AnalyticsEventsParamCardCategory = @"param_card_category";
+NSString * const AnalyticsEventsScreenHome = @"view_home_event";
+NSString * const AnalyticsEventsScreenBookmarks = @"view_bookmarks_event";
+NSString * const AnalyticsEventsScreenMapFull = @"view_map_event";
+NSString * const AnalyticsEventsScreenDetails = @"view_details_event";
+NSString * const AnalyticsEventsScreenMapItem = @"screen_map_feed_event";
+NSString * const AnalyticsEventsParamCardName = @"param_card_name";
+NSString * const AnalyticsEventsParamCardCategory = @"param_card_category";
 
-const NSString* AnalyticsEventsPressCard = @"home_card_event";
-const NSString* AnalyticsEventsSaveCard = @"home_save_card_event";
-const NSString* AnalyticsEventsUnsaveCard = @"home_unsave_card_event";
-const NSString* AnalyticsEventsSeeAll = @"home_see_all_event";
+NSString * const AnalyticsEventsPressCard = @"home_card_event";
+NSString * const AnalyticsEventsSaveCard = @"home_save_card_event";
+NSString * const AnalyticsEventsUnsaveCard = @"home_unsave_card_event";
+NSString * const AnalyticsEventsSeeAll = @"home_see_all_event";
 
-const NSString* AnalyticsEventsPressSavedCategory = @"saved_category_event";
-const NSString* AnalyticsEventsPressCardSaved = @"saved_card_event";
-const NSString* AnalyticsEventsParamCategoryName = @"param_category_name";
+NSString * const AnalyticsEventsPressSavedCategory = @"saved_category_event";
+NSString * const AnalyticsEventsPressCardSaved = @"saved_card_event";
+NSString * const AnalyticsEventsParamCategoryName = @"param_category_name";
 
-const NSString* AnalyticsEventsSearchType = @"home_search_result_event";
-const NSString* AnalyticsEventsPressSearchResult = @"home_search_select_event";
-const NSString* AnalyticsEventsParamSearchQuery=@"param_search_query";
+NSString * const AnalyticsEventsSearchType = @"home_search_result_event";
+NSString * const AnalyticsEventsPressSearchResult = @"home_search_select_event";
+NSString * const AnalyticsEventsParamSearchQuery=@"param_search_query";
 
-const NSString* AnalyticsEventsTimeSpentInActiveState = @"time_active_event";
+NSString * const AnalyticsEventsTimeSpentInActiveState = @"time_active_event";
 
-const NSString* AnalyticsEventsDetailsSave = @"card_details_save_event";
-const NSString* AnalyticsEventsDetailsUnsave = @"card_details_unsave_event";
-const NSString* AnalyticsEventsDetailsOpenMap = @"card_details_map_event";
-const NSString* AnalyticsEventsDetailsScrollToEnd = @"card_details_scroll";
-const NSString* AnalyticsEventsPressCoords = @"card_details_coordinates_event";
-const NSString* AnalyticsEventsDetailsBack = @"card_details_close_event";
-const NSString* AnalyticsEventsParamLinkType = @"param_link_type";
+NSString * const AnalyticsEventsDetailsSave = @"card_details_save_event";
+NSString * const AnalyticsEventsDetailsUnsave = @"card_details_unsave_event";
+NSString * const AnalyticsEventsDetailsOpenMap = @"card_details_map_event";
+NSString * const AnalyticsEventsDetailsScrollToEnd = @"card_details_scroll";
+NSString * const AnalyticsEventsPressCoords = @"card_details_coordinates_event";
+NSString * const AnalyticsEventsDetailsBack = @"card_details_close_event";
+NSString * const AnalyticsEventsParamLinkType = @"param_link_type";
+ 
+NSString * const AnalyticsEventsMapFilterAll = @"map_all_event";
+NSString * const AnalyticsEventsMapFilterTerritories = @"map_terr_event";
+NSString * const AnalyticsEventsMapFilterArchitecture = @"map_arch_event";
+NSString * const AnalyticsEventsMapFilterReligion = @"map_religion_event";
+NSString * const AnalyticsEventsMapFilterNature = @"map_nature_event";
+NSString * const AnalyticsEventsMapFilterMuseums = @"map_museums_event";
+NSString * const AnalyticsEventsMapFilterWarMemorials = @"map_war_memorials_event";
+NSString * const AnalyticsEventsMapFilterOther = @"map_other_event";
+NSString * const AnalyticsEventsMapFilterFoot = @"map_foot_event";
+NSString * const AnalyticsEventsMapFilterBike = @"map_velo_event";
+NSString * const AnalyticsEventsMapFilterWater = @"map_water_event";
 
-const NSString* AnalyticsEventsMapFilterAll = @"map_all_event";
-const NSString* AnalyticsEventsMapFilterTerritories = @"map_terr_event";
-const NSString* AnalyticsEventsMapFilterArchitecture = @"map_arch_event";
-const NSString* AnalyticsEventsMapFilterReligion = @"map_religion_event";
-const NSString* AnalyticsEventsMapFilterNature = @"map_nature_event";
-const NSString* AnalyticsEventsMapFilterMuseums = @"map_museums_event";
-const NSString* AnalyticsEventsMapFilterWarMemorials = @"map_war_memorials_event";
-const NSString* AnalyticsEventsMapFilterOther = @"map_other_event";
-const NSString* AnalyticsEventsMapFilterFoot = @"map_foot_event";
-const NSString* AnalyticsEventsMapFilterBike = @"map_velo_event";
-const NSString* AnalyticsEventsMapFilterWater = @"map_water_event";
+NSString * const AnalyticsEventsMapSearch = @"map_search_event";
+NSString * const AnalyticsEventsMapInteraction = @"map_point_interaction_event";
+NSString * const AnalyticsEventsParamMapInteractionSave = @"param_save";
+NSString * const AnalyticsEventsParamMapInteractionLearnMore = @"param_learn_more";
+NSString * const AnalyticsEventsMapSearchType = @"map_search_result_event";
+NSString * const AnalyticsEventsMapPressSearchResult = @"map_search_select_event";
+NSString * const AnalyticsEventsParamMapFilterCheck = @"param_map_filter_check";
 
-const NSString* AnalyticsEventsMapSearch = @"map_search_event";
-const NSString* AnalyticsEventsMapInteraction = @"map_point_interaction_event";
-const NSString* AnalyticsEventsParamMapInteractionSave = @"param_save";
-const NSString* AnalyticsEventsParamMapInteractionLearnMore = @"param_learn_more";
-const NSString* AnalyticsEventsMapSearchType = @"map_search_result_event";
-const NSString* AnalyticsEventsMapPressSearchResult = @"map_search_select_event";
-const NSString* AnalyticsEventsParamMapFilterCheck = @"param_map_filter_check";
+NSString * const AnalyticsEventsLifeTimeHomeScreen = @"home_lifetime";
+NSString * const AnalyticsEventsLifeTimeDetailsScreen = @"card_details_lifetime";
+NSString * const AnalyticsEventsLifeTimeFullMapScreen = @"map_lifetime";
 
-const NSString* AnalyticsEventsLifeTimeHomeScreen = @"home_lifetime";
-const NSString* AnalyticsEventsLifeTimeDetailsScreen = @"card_details_lifetime";
-const NSString* AnalyticsEventsLifeTimeFullMapScreen = @"map_lifetime";
+NSString * const AnalyticsEventsParamTimeInterval = @"param_time_interval";
 
-const NSString* AnalyticsEventsParamTimeInterval = @"param_time_interval";
-
-const NSString* AnalyticsEventsGalleryPictureView = @"card_details_switch_photo";
-
-
-
+NSString * const AnalyticsEventsGalleryPictureView = @"card_details_switch_photo";

--- a/ios/utilities/LocaleConstants.h
+++ b/ios/utilities/LocaleConstants.h
@@ -7,6 +7,6 @@
 
 #import <Foundation/Foundation.h>
 
-FOUNDATION_EXPORT const NSString * LocaleLanguageCodeLegacy;
-FOUNDATION_EXPORT const NSString * LocaleLanguageCodeDefault;
-FOUNDATION_EXPORT const NSString * SupportedLanguageCodes;
+FOUNDATION_EXPORT NSString * const LocaleLanguageCodeLegacy;
+FOUNDATION_EXPORT NSString * const LocaleLanguageCodeDefault;
+FOUNDATION_EXPORT NSString * const SupportedLanguageCodes;

--- a/ios/utilities/LocaleConstants.m
+++ b/ios/utilities/LocaleConstants.m
@@ -7,6 +7,6 @@
 
 #import "LocaleConstants.h"
 
-const NSString * LocaleLanguageCodeLegacy = @"ru";
-const NSString * LocaleLanguageCodeDefault = @"en";
-const NSString * SupportedLanguageCodes = @"en,ru,zh";
+NSString * const LocaleLanguageCodeLegacy = @"ru";
+NSString * const LocaleLanguageCodeDefault = @"en";
+NSString * const SupportedLanguageCodes = @"en,ru,zh";

--- a/ios/utilities/ViewUtils.h
+++ b/ios/utilities/ViewUtils.h
@@ -8,6 +8,4 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-UIWindow* getCurrentWindow();
-
-
+UIWindow* getCurrentWindow(void);

--- a/ios/utilities/ViewUtils.m
+++ b/ios/utilities/ViewUtils.m
@@ -7,7 +7,7 @@
 
 #import "ViewUtils.h"
 
-UIWindow* getCurrentWindow() {
+UIWindow* getCurrentWindow(void) {
   UIWindow *currentWindow = [UIApplication.sharedApplication.windows filteredArrayUsingPredicate:
                              [NSPredicate predicateWithBlock:^BOOL(UIWindow * _Nullable window, NSDictionary<NSString *,id> * _Nullable bindings) {
     return window.isKeyWindow;

--- a/ios/views/CommonButtonWithProgress/CommonButtonWithProgress.m
+++ b/ios/views/CommonButtonWithProgress/CommonButtonWithProgress.m
@@ -30,8 +30,13 @@
   if (self.progressIndicator != nil) {
     return self.progressIndicator;
   }
-  self.progressIndicator = [[UIActivityIndicatorView alloc]
-                                      initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+  if (@available(iOS 13.0, *)) {
+    self.progressIndicator = [[UIActivityIndicatorView alloc]
+                              initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+  } else {
+    self.progressIndicator = [[UIActivityIndicatorView alloc]
+                              initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+  }
   self.progressIndicator.color = [ColorsLegacy get].white;
   return self.progressIndicator;
 }
@@ -48,8 +53,6 @@
 - (void)setInProgress:(BOOL)inProgress {
   _inProgress = inProgress;
   if (inProgress) {
-    UIActivityIndicatorView *progressIndicator = [[UIActivityIndicatorView alloc]
-                                        initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     self.labelBackup = self.currentTitle;
     [self setLabel:@""];
     [self addActivityIndicator];

--- a/ios/views/CommonTextField/CommonTextField.swift
+++ b/ios/views/CommonTextField/CommonTextField.swift
@@ -8,13 +8,4 @@
 import UIKit
 
 class CommonTextField: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
-
 }

--- a/ios/views/PassCodeTextField/NumberView/NumberViewConstants.m
+++ b/ios/views/PassCodeTextField/NumberView/NumberViewConstants.m
@@ -7,5 +7,5 @@
 
 #import "NumberViewConstants.h"
 
-FOUNDATION_EXPORT const CGFloat NumberViewHeight = 48.0;
-FOUNDATION_EXPORT const CGFloat NumberViewWidth = 36.0;
+const CGFloat NumberViewHeight = 48.0;
+const CGFloat NumberViewWidth = 36.0;


### PR DESCRIPTION
  - bump deployment target to 12.4
  - remove duplicates awsconfiguration.json & amplifyconfiguration.json from pbxproj
  - add missing methods for protocol confirmation
  - add missing methods from definitions
  - comment unused variables
  - refactor const NSString to silence warnings
  - fix non-mutable collections warnings
  - wrap UIActivityIndicatorView with ios13
  - ignore vendor files with ruby

### What does this PR do:

Warnings before - 3189. 
Warnings after - 27.

