### PR TITLE
fix(638): settings UI using settings model - part1

### DIFF
--- a/ios/controllers/SettingsController/SettingsController.h
+++ b/ios/controllers/SettingsController/SettingsController.h
@@ -6,15 +6,20 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "UserModelObserver.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SettingsEntry;
 @class SettingsModel;
+@class UserModel;
+@class UserController;
 
-@interface SettingsController : NSObject
+@interface SettingsController : NSObject<UserModelObserver>
 
-- (instancetype)initWithModel:(SettingsModel *)settingsModel;
+- (instancetype)initWithModel:(SettingsModel *)settingsModel
+               userController:(UserController *)userController
+                             userModel:(UserModel *)userModel;
 
 - (void)interactWithSetting:(SettingsEntry *)entry
            onViewController:(UIViewController *)viewController;

--- a/ios/controllers/SettingsController/SettingsController.m
+++ b/ios/controllers/SettingsController/SettingsController.m
@@ -92,7 +92,6 @@
   // Find 4th tab controller in application.
   UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
   SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
-  BOOL root = settingsViewController == self;
   
   __weak typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
@@ -169,7 +168,7 @@
   };
   
   SettingsGroup *authGroup = [self.model.tree.groups[0] copy];
-  authGroup.entries = @[authEntry];
+  authGroup.entries = [[NSMutableArray alloc] initWithArray:@[authEntry]];
   
   [self.model updateGroup:authGroup];
 }
@@ -192,7 +191,8 @@
 #pragma mark - Profile screen
   SettingsScreen *screenProfile = [SettingsScreen new];
   screenProfile.name = @"";
-  screenProfile.groups = @[logoutGroup, deleteAccountGroup];
+  screenProfile.groups =
+  [[NSMutableArray alloc] initWithArray:@[logoutGroup, deleteAccountGroup]];
   
   
 #pragma mark - Auth group
@@ -201,7 +201,7 @@
   authEntry.screen = screenProfile;
   
   SettingsGroup *authGroup = [self.model.tree.groups[0] copy];
-  authGroup.entries = @[authEntry];
+  authGroup.entries = [[NSMutableArray alloc] initWithArray:@[authEntry]];
   
   [self.model updateGroup:authGroup];
 }

--- a/ios/controllers/SettingsController/SettingsController.m
+++ b/ios/controllers/SettingsController/SettingsController.m
@@ -92,6 +92,9 @@
                         toCurrentState:(UserModelState)currentState {
   // Find 4th tab controller in application.
   UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
+  if (tabController.viewControllers.count < 4) {
+    return;
+  }
   SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
   
   __weak typeof(self) weakSelf = self;

--- a/ios/controllers/SettingsController/SettingsController.m
+++ b/ios/controllers/SettingsController/SettingsController.m
@@ -65,6 +65,7 @@
     [[SettingsViewController alloc] initWithSettingsController:self
                                                  settingsModel:self.model
                                                 settingsScreen:entryNavigate.screen];
+    settingsViewController.title = entryNavigate.name;
     [viewController.navigationController pushViewController:settingsViewController animated:YES];
     return;
   }

--- a/ios/controllers/SettingsController/SettingsController.m
+++ b/ios/controllers/SettingsController/SettingsController.m
@@ -7,69 +7,203 @@
 
 #import "SettingsController.h"
 #import "SettingsModel.h"
+#import "UserModel.h"
+#import "UserController.h"
 #import "SettingsEntry.h"
 #import "SettingsGroup.h"
+#import "SettingsScreen.h"
 #import "SettingsEntryToggle.h"
 #import "SettingsEntrySelect.h"
 #import "SettingsEntryAction.h"
 #import "SettingsEntryNavigate.h"
+#import "SettingsEntryAuthLoggedOut.h"
+#import "SettingsEntryAuthLoggedIn.h"
 #import "SettingsViewController.h"
+#import "UserFetchErrorViewController.h"
+#import "ProfileTableViewController.h"
+#import "LoginViewController.h"
 
 @interface SettingsController()
 
 @property (strong, nonatomic) SettingsModel *model;
 
+@property (strong, nonatomic) UserModel *userModel;
+@property (strong, nonatomic) UserController *userController;
+
 @end
 
 @implementation SettingsController
 
-- (instancetype)initWithModel:(SettingsModel *)settingsModel {
-    if (self = [super init]) {
-        _model = settingsModel;
-    }
-    return self;
+- (instancetype)initWithModel:(SettingsModel *)settingsModel
+               userController:(UserController *)userController
+                    userModel:(UserModel *)userModel {
+  if (self = [super init]) {
+    _model = settingsModel;
+    _userController = userController;
+    _userModel = userModel;
+  }
+  return self;
 }
 
 - (void)interactWithSetting:(SettingsEntry *)entry
            onViewController:(UIViewController *)viewController {
-    if ([entry isKindOfClass:[SettingsEntryToggle class]]) {
-        SettingsEntryToggle *entryToggleUpdated = [SettingsEntryToggle new];
-        SettingsEntryToggle *entryToggle = (SettingsEntryToggle *)entry;
-        entryToggleUpdated.enabled = !entryToggle.enabled;
-        [self.model updateEntry:entryToggleUpdated];
+  if ([entry isKindOfClass:[SettingsEntryToggle class]]) {
+    SettingsEntryToggle *entryToggleUpdated = [SettingsEntryToggle new];
+    SettingsEntryToggle *entryToggle = (SettingsEntryToggle *)entry;
+    entryToggleUpdated.enabled = !entryToggle.enabled;
+    [self.model updateEntry:entryToggleUpdated];
+    return;
+  }
+  if ([entry isKindOfClass:[SettingsEntryAction class]]) {
+    SettingsEntryAction *entryAction = (SettingsEntryAction *)entry;
+    entryAction.doAction(viewController);
+    return;
+  }
+  if ([entry isKindOfClass:[SettingsEntryNavigate class]]) {
+    SettingsEntryNavigate *entryNavigate = (SettingsEntryNavigate *)entry;
+    SettingsViewController *settingsViewController =
+    [[SettingsViewController alloc] initWithSettingsController:self
+                                                 settingsModel:self.model
+                                                settingsScreen:entryNavigate.screen];
+    [viewController.navigationController pushViewController:settingsViewController animated:YES];
+    return;
+  }
+  if ([entry isKindOfClass:[SettingsEntrySelect class]]) {
+    SettingsEntrySelect *entrySelect = (SettingsEntrySelect *)entry;
+    BOOL selected = entrySelect.selected;
+    SettingsGroup *groupUpdated = [entrySelect.parentGroup copy];
+    
+    [groupUpdated.entries enumerateObjectsUsingBlock:^(SettingsEntry * _Nonnull entry,
+                                                       NSUInteger idx, BOOL * _Nonnull stop) {
+      SettingsEntrySelect *entrySelectUpdated = (SettingsEntrySelect *)entry;
+      if ([entrySelectUpdated.uid isEqual:entrySelect.uid]) {
+        entrySelectUpdated.selected = selected;
         return;
-    }
-    if ([entry isKindOfClass:[SettingsEntryAction class]]) {
-        SettingsEntryAction *entryAction = (SettingsEntryAction *)entry;
-        entryAction.doAction(viewController);
+      }
+      entrySelectUpdated.selected = NO;
+    }];
+    [self.model updateGroup:groupUpdated];
+    return;
+  }
+}
+
+- (void)onUserModelStateTransitionFrom:(UserModelState)prevState
+                        toCurrentState:(UserModelState)currentState {
+  // Find 4th tab controller in application.
+  UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
+  SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
+  BOOL root = settingsViewController == self;
+  
+  __weak typeof(self) weakSelf = self;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __weak typeof(self) strongSelf = weakSelf;
+      BOOL fetched = prevState == UserModelStateFetchingInProgress &&
+      currentState == UserModelStateFetched;
+      if (fetched && strongSelf.userModel.error != nil) {
+        UserFetchErrorViewController *errorViewController = [[UserFetchErrorViewController alloc] initWithController:self.userController model:self.userModel];
+        [settingsViewController.navigationController pushViewController:errorViewController animated:YES];
         return;
-    }
-    if ([entry isKindOfClass:[SettingsEntryNavigate class]]) {
-        SettingsEntryNavigate *entryNavigate = (SettingsEntryNavigate *)entry;
-        SettingsViewController *settingsViewController =
-        [[SettingsViewController alloc] initWithSettingsController:self
-                                                     settingsModel:self.model
-                                                 settingsScreen:entryNavigate.screen];
-        [viewController.navigationController pushViewController:settingsViewController animated:YES];
+      }
+      BOOL signedIn = strongSelf.userModel.signedIn;
+      if (fetched && signedIn) {
+        [self updateAuthGroupWhenLoggedIn:NO];
         return;
-    }
-    if ([entry isKindOfClass:[SettingsEntrySelect class]]) {
-        SettingsEntrySelect *entrySelect = (SettingsEntrySelect *)entry;
-        BOOL selected = entrySelect.selected;
-        SettingsGroup *groupUpdated = [entrySelect.parentGroup copy];
-      
-        [groupUpdated.entries enumerateObjectsUsingBlock:^(SettingsEntry * _Nonnull entry,
-                                                           NSUInteger idx, BOOL * _Nonnull stop) {
-            SettingsEntrySelect *entrySelectUpdated = (SettingsEntrySelect *)entry;
-            if ([entrySelectUpdated.uid isEqual:entrySelect.uid]) {
-                entrySelectUpdated.selected = selected;
-                return;
-            }
-            entrySelectUpdated.selected = NO;
-        }];
-        [self.model updateGroup:groupUpdated];
+      }
+      if (prevState == UserModelStateConfirmCodeInProgress &&
+          currentState == UserModelStateSignUpSuccess) {
+        [self updateAuthGroupWhenLoggedIn:NO];
         return;
+      }
+      if (prevState == UserModelStateSignInInProgress &&
+          currentState == UserModelStateSignedIn) {
+        [self updateAuthGroupWhenLoggedIn:NO];
+        return;
+      }
+      if (prevState == UserModelStatePasswordResetConfirmCodeInProgress &&
+          currentState == UserModelStatePasswordResetSuccess) {
+        [self updateAuthGroupWhenLoggedIn:NO];
+        return;
+      }
+      if (prevState == UserModelStateSignOutInProgress &&
+          currentState == UserModelStateFetched) {
+        [self updateAuthGroupWhenLoggedOut:NO];
+        return;
+      }
+      if (prevState == UserModelStateNotFetched && currentState == UserModelStateFetchingInProgress) {
+        [self updateAuthGroupWhenLoggedOut:YES];
+        return;
+      }
+      if (prevState == UserModelStateFetchingInProgress && currentState == UserModelStateFetched) {
+        [self updateAuthGroupWhenLoggedOut:NO];
+        return;
+      }
+      if (prevState == UserModelStateFetchingInProgress && currentState == UserModelStateNotFetched) {
+        [self updateAuthGroupWhenLoggedOut:NO];
+        return;
+      }
+      if (prevState == UserModelStateSignedIn &&
+          currentState == UserModelStateSignOutInProgress) {
+        [self updateAuthGroupWhenLoggedIn:YES];
+        return;
+      }
+    });
+  });
+}
+
+- (void)updateAuthGroupWhenLoggedOut:(BOOL)progress {
+#pragma mark - Auth group
+  SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
+  authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  authEntry.doAction = ^void(UIViewController *activeViewController) {
+    ProfileTableViewController *profileTableViewController = (ProfileTableViewController *)activeViewController;
+    LoginViewController *loginViewController =
+    [[LoginViewController alloc] initWithController:profileTableViewController.userController
+                                              model:profileTableViewController.userModel];
+    loginViewController.title = NSLocalizedString(@"LogInTitle", @"");
+    UINavigationController *loginViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:loginViewController];
+    if (@available(iOS 13.0, *)) {
+      [loginViewControllerWithNavigation setModalInPresentation:YES];
     }
+    [activeViewController presentViewController:loginViewControllerWithNavigation animated:YES completion:^{}];
+  };
+  
+  SettingsGroup *authGroup = [self.model.tree.groups[0] copy];
+  authGroup.entries = @[authEntry];
+  
+  [self.model updateGroup:authGroup];
+}
+
+- (void)updateAuthGroupWhenLoggedIn:(BOOL)progress{
+#pragma mark - Log out group
+  SettingsEntryAction *logoutEntry = [SettingsEntryAction new];
+  logoutEntry.name = NSLocalizedString(@"ProfileScreenLogOut", @"");
+  logoutEntry.doAction = ^void(UIViewController *activeViewController) {};
+  
+  SettingsGroup *logoutGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[logoutEntry]];
+#pragma mark - Delete account group
+  SettingsEntryAction *deleteAccountEntry = [SettingsEntryAction new];
+  deleteAccountEntry.name = NSLocalizedString(@"ProfileScreenDelete", @"");
+  deleteAccountEntry.doAction = ^void(UIViewController *activeViewController) {};
+  
+  SettingsGroup *deleteAccountGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[deleteAccountEntry]];
+#pragma mark - Profile screen
+  SettingsScreen *screenProfile = [SettingsScreen new];
+  screenProfile.name = @"";
+  screenProfile.groups = @[logoutGroup, deleteAccountGroup];
+  
+  
+#pragma mark - Auth group
+  SettingsEntryAuthLoggedIn *authEntry = [SettingsEntryAuthLoggedIn new];
+  authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  authEntry.screen = screenProfile;
+  
+  SettingsGroup *authGroup = [self.model.tree.groups[0] copy];
+  authGroup.entries = @[authEntry];
+  
+  [self.model updateGroup:authGroup];
 }
 
 @end

--- a/ios/en.lproj/Localizable.strings
+++ b/ios/en.lproj/Localizable.strings
@@ -86,6 +86,15 @@
 
 "ProfileTableViewCellSignedMainTitleLabel" = "You are authorized";
 
+//SettingsViewController
+"SettingsViewControllerAuthCellTitleAuthorized" = "You are authorized";
+"SettingsViewControllerAuthCellTitleAuthorizedNot" = "You are not authorized";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Authorizing";
+
+"SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Authorize or Sign up";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Wait while the login is being verified";
+
+
 "CodeConfirmationScreenTitle" = "Email confirmation";
 "CodeConfirmationScreenHeader" = "Confirm sign up";
 "CodeConfirmationScreenHint" = "enter confirmation code from e-mail %@";

--- a/ios/en.lproj/Localizable.strings
+++ b/ios/en.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Authorize or Sign up";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Wait while the login is being verified";
 
+"SettingsViewControllerGeneralGroupTitle" = "Settings";
 "SettingsViewControllerLanguageCellTitle" = "Language";
 "SettingsViewControllerLanguageCellValueEnglish" = "English";
 "SettingsViewControllerLanguageCellValueRussian" = "Russian";
@@ -103,6 +104,7 @@
 "SettingsViewControllerCacheAlertMessageHeader" = "Clear cache?";
 "SettingsViewControllerCacheAlertMessageBody" = "This will reduce app size";
 
+"SettingsViewControllerAboutGroupTitle" = "Information";
 "SettingsViewControllerTermsCellTitle" = "Terms and Conditions";
 "SettingsViewControllerPrivacyCellTitle" = "Privacy Policy";
 

--- a/ios/en.lproj/Localizable.strings
+++ b/ios/en.lproj/Localizable.strings
@@ -94,6 +94,17 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Authorize or Sign up";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Wait while the login is being verified";
 
+"SettingsViewControllerLanguageCellTitle" = "Language";
+"SettingsViewControllerLanguageCellValueEnglish" = "English";
+"SettingsViewControllerLanguageCellValueRussian" = "Russian";
+"SettingsViewControllerLanguageCellValueChineseSimplified" = "Chinese Simplified";
+
+"SettingsViewControllerCacheCellTitle" = "Clear cache";
+"SettingsViewControllerCacheAlertMessageHeader" = "Clear cache?";
+"SettingsViewControllerCacheAlertMessageBody" = "This will reduce app size";
+
+"SettingsViewControllerTermsCellTitle" = "Terms and Conditions";
+"SettingsViewControllerPrivacyCellTitle" = "Privacy Policy";
 
 "CodeConfirmationScreenTitle" = "Email confirmation";
 "CodeConfirmationScreenHeader" = "Confirm sign up";

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		5ADF0352284524B000D98E9A /* NumberViewConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADF0351284524B000D98E9A /* NumberViewConstants.m */; };
 		5AF8D58D260C7D8A001CE702 /* GalleryImagePlaceholder.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF8D588260C7D8A001CE702 /* GalleryImagePlaceholder.m */; };
 		5AF8D58E260C7D8A001CE702 /* CommonButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF8D58B260C7D8A001CE702 /* CommonButton.m */; };
+		5AFA7C792993E305005C413F /* SettingsScreenRoot.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFA7C782993E305005C413F /* SettingsScreenRoot.m */; };
 		5AFB8FD928F9608B009E729E /* AccessibilityIdentifiers.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFB8FD828F9608B009E729E /* AccessibilityIdentifiers.m */; };
 		5AFFD0F52850E81A009E5AB8 /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFD0F42850E81A009E5AB8 /* ProfileViewController.m */; };
 		5AFFD0FA2851FE88009E5AB8 /* UserFetchProgressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFD0F92851FE88009E5AB8 /* UserFetchProgressViewController.m */; };
@@ -712,6 +713,8 @@
 		5AF8D58A260C7D8A001CE702 /* CommonButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonButton.h; sourceTree = "<group>"; };
 		5AF8D58B260C7D8A001CE702 /* CommonButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommonButton.m; sourceTree = "<group>"; };
 		5AF8D58C260C7D8A001CE702 /* GalleryImagePlaceholder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GalleryImagePlaceholder.h; sourceTree = "<group>"; };
+		5AFA7C772993E305005C413F /* SettingsScreenRoot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsScreenRoot.h; sourceTree = "<group>"; };
+		5AFA7C782993E305005C413F /* SettingsScreenRoot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsScreenRoot.m; sourceTree = "<group>"; };
 		5AFB8FD728F9608B009E729E /* AccessibilityIdentifiers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityIdentifiers.h; sourceTree = "<group>"; };
 		5AFB8FD828F9608B009E729E /* AccessibilityIdentifiers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AccessibilityIdentifiers.m; sourceTree = "<group>"; };
 		5AFFD0F32850E81A009E5AB8 /* ProfileViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProfileViewController.h; sourceTree = "<group>"; };
@@ -869,6 +872,8 @@
 				5A78A4EB29573040007749F3 /* SettingsGroupSelect.m */,
 				5A2C90572957244D008D8C7E /* SettingsScreen.h */,
 				5A2C90582957244D008D8C7E /* SettingsScreen.m */,
+				5AFA7C772993E305005C413F /* SettingsScreenRoot.h */,
+				5AFA7C782993E305005C413F /* SettingsScreenRoot.m */,
 			);
 			path = SettingsModel;
 			sourceTree = "<group>";
@@ -2510,6 +2515,7 @@
 			files = (
 				5AD1B2C92972D33E005CED4E /* SettingsSelectTableViewCell.m in Sources */,
 				5A775B8626064C9000CEFC78 /* CoreDataService.m in Sources */,
+				5AFA7C792993E305005C413F /* SettingsScreenRoot.m in Sources */,
 				5A775E0F26077A7D00CEFC78 /* SlideCollectionViewCell.m in Sources */,
 				5AD1B2C12972D300005CED4E /* SettingsActionTableViewCell.m in Sources */,
 				5A775DFF26077A7D00CEFC78 /* CategoriesFilterViewConstants.m in Sources */,

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		5A2C989C29520FEE007A822F /* SettingsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A2C989B29520FEE007A822F /* SettingsController.m */; };
 		5A333C5B273C55A400F95180 /* SearchViewControllerUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A333C5A273C55A400F95180 /* SearchViewControllerUtils.m */; };
 		5A39D6EF26B34C04008FC20C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5A39D6F126B34C04008FC20C /* Localizable.strings */; };
+		5A4B5CAD298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A4B5CAC298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.m */; };
 		5A53584827A999DC0017A40F /* IndexModelData.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A53584727A999DC0017A40F /* IndexModelData.m */; };
 		5A53584B27B4162A0017A40F /* LabelledButtonGroupTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A53584A27B4162A0017A40F /* LabelledButtonGroupTableViewCell.m */; };
 		5A5DCEAE2687E5E7003025F5 /* ArrayUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A5DCEAD2687E5E7003025F5 /* ArrayUtils.m */; };
@@ -334,6 +335,8 @@
 		5A39D6F026B34C04008FC20C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5A39D6F326B34C0A008FC20C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5A39D6F526B6D255008FC20C /* MainViewControllerConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainViewControllerConstants.h; sourceTree = "<group>"; };
+		5A4B5CAB298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsAuthTableViewCellUtils.h; sourceTree = "<group>"; };
+		5A4B5CAC298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsAuthTableViewCellUtils.m; sourceTree = "<group>"; };
 		5A53584627A999DC0017A40F /* IndexModelData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IndexModelData.h; sourceTree = "<group>"; };
 		5A53584727A999DC0017A40F /* IndexModelData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IndexModelData.m; sourceTree = "<group>"; };
 		5A53584927B4162A0017A40F /* LabelledButtonGroupTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LabelledButtonGroupTableViewCell.h; sourceTree = "<group>"; };
@@ -967,6 +970,8 @@
 			children = (
 				5A295C242989388A00A109F0 /* SettingsAuthTableViewCell.h */,
 				5A295C252989388A00A109F0 /* SettingsAuthTableViewCell.m */,
+				5A4B5CAB298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.h */,
+				5A4B5CAC298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.m */,
 			);
 			path = SettingsAuthTableViewCell;
 			sourceTree = "<group>";
@@ -2230,9 +2235,9 @@
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 53APD5F9YQ;
+						DevelopmentTeam = NWSTPFC433;
 						LastSwiftMigration = 1130;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -2523,6 +2528,7 @@
 				5A775E1226077A7D00CEFC78 /* SearchViewController.m in Sources */,
 				5A2144B1266B988700582901 /* MapViewState.m in Sources */,
 				5A775B6026064C9000CEFC78 /* MapItem.m in Sources */,
+				5A4B5CAD298E76A1002D4B23 /* SettingsAuthTableViewCellUtils.m in Sources */,
 				5A775E1426077A7D00CEFC78 /* UISearchControllerNoCancel.m in Sources */,
 				5A8EB1A1264E7DF000333F1E /* ItemDetailsMapViewController.m in Sources */,
 				5A6685D52858898C008E193E /* AuthErrors.swift in Sources */,
@@ -2738,11 +2744,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 26;
-				DEVELOPMENT_TEAM = 53APD5F9YQ;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 53APD5F9YQ;
+				DEVELOPMENT_TEAM = NWSTPFC433;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -2762,10 +2767,9 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.greentravel.radzima;
+				PRODUCT_BUNDLE_IDENTIFIER = com.greentravel.radzima1;
 				PRODUCT_NAME = "Radzima Dev";
-				PROVISIONING_PROFILE_SPECIFIER = "EPM_SLR_In-House";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "EPM_SLR_In-House";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "greenTravel-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		5AB4AFD127B5B20E00C74857 /* StoredPlaceDetails+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4AFCE27B5B20E00C74857 /* StoredPlaceDetails+CoreDataProperties.m */; };
 		5AB4AFD227B5B20E00C74857 /* StoredInformationReference+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4AFCA27B5B20E00C74857 /* StoredInformationReference+CoreDataProperties.m */; };
 		5AB4AFD527C27B2B00C74857 /* DetailsScreenController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4AFD427C27B2B00C74857 /* DetailsScreenController.m */; };
+		5AB6CEDA297DA7A800C71366 /* SettingsBaseTableViewCellConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AB6CED9297DA7A800C71366 /* SettingsBaseTableViewCellConfig.m */; };
 		5ABCA31226B97D68001CDF74 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5ABCA31126B97D68001CDF74 /* GoogleService-Info.plist */; };
 		5AC2C2A3263EC2E700CCBE63 /* BottomSheetView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A94AF3F263EB76F00AC4E7B /* BottomSheetView.m */; };
 		5AC7B3A426FFB58200531FB3 /* BottomSheetPresentationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AC7B3A326FFB58200531FB3 /* BottomSheetPresentationController.m */; };
@@ -205,6 +206,9 @@
 		5AD1B2C52972D319005CED4E /* SettingsToggleTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2C42972D319005CED4E /* SettingsToggleTableViewCell.m */; };
 		5AD1B2C92972D33E005CED4E /* SettingsSelectTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2C82972D33E005CED4E /* SettingsSelectTableViewCell.m */; };
 		5AD1B2CD2972D353005CED4E /* SettingsNavigateTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2CC2972D353005CED4E /* SettingsNavigateTableViewCell.m */; };
+		5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */; };
+		5AD1B2D3297C1F4D005CED4E /* SettingsEntryLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */; };
+		5AD1B2D7297C3AF8005CED4E /* SettingsBaseTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2D6297C3AF8005CED4E /* SettingsBaseTableViewCell.m */; };
 		5AD1F3842948C7F400ED288D /* SettingsEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1F3832948C7E900ED288D /* SettingsEntry.m */; };
 		5AD2DA3026FDD55900876841 /* Settings_ReleaseProduction.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 5AD2DA2F26FDD55800876841 /* Settings_ReleaseProduction.bundle */; };
 		5AD2DA3426FDED7B00876841 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 5AD2DA3326FDED7B00876841 /* Settings.bundle */; };
@@ -622,6 +626,8 @@
 		5AB4AFCE27B5B20E00C74857 /* StoredPlaceDetails+CoreDataProperties.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "StoredPlaceDetails+CoreDataProperties.m"; sourceTree = "<group>"; };
 		5AB4AFD327C27B2B00C74857 /* DetailsScreenController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DetailsScreenController.h; sourceTree = "<group>"; };
 		5AB4AFD427C27B2B00C74857 /* DetailsScreenController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DetailsScreenController.m; sourceTree = "<group>"; };
+		5AB6CED8297DA7A800C71366 /* SettingsBaseTableViewCellConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsBaseTableViewCellConfig.h; sourceTree = "<group>"; };
+		5AB6CED9297DA7A800C71366 /* SettingsBaseTableViewCellConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsBaseTableViewCellConfig.m; sourceTree = "<group>"; };
 		5ABCA31126B97D68001CDF74 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5AC7B3A226FFB58200531FB3 /* BottomSheetPresentationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BottomSheetPresentationController.h; sourceTree = "<group>"; };
 		5AC7B3A326FFB58200531FB3 /* BottomSheetPresentationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BottomSheetPresentationController.m; sourceTree = "<group>"; };
@@ -639,6 +645,12 @@
 		5AD1B2C82972D33E005CED4E /* SettingsSelectTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsSelectTableViewCell.m; sourceTree = "<group>"; };
 		5AD1B2CB2972D353005CED4E /* SettingsNavigateTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsNavigateTableViewCell.h; sourceTree = "<group>"; };
 		5AD1B2CC2972D353005CED4E /* SettingsNavigateTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsNavigateTableViewCell.m; sourceTree = "<group>"; };
+		5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryAuth.h; sourceTree = "<group>"; };
+		5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryAuth.m; sourceTree = "<group>"; };
+		5AD1B2D1297C1F4D005CED4E /* SettingsEntryLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryLink.h; sourceTree = "<group>"; };
+		5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryLink.m; sourceTree = "<group>"; };
+		5AD1B2D5297C3AF8005CED4E /* SettingsBaseTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsBaseTableViewCell.h; sourceTree = "<group>"; };
+		5AD1B2D6297C3AF8005CED4E /* SettingsBaseTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsBaseTableViewCell.m; sourceTree = "<group>"; };
 		5AD1F3812948C4A100ED288D /* SettingsModelObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsModelObserver.h; sourceTree = "<group>"; };
 		5AD1F3822948C7E900ED288D /* SettingsEntry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntry.h; sourceTree = "<group>"; };
 		5AD1F3832948C7E900ED288D /* SettingsEntry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntry.m; sourceTree = "<group>"; };
@@ -830,6 +842,10 @@
 				5A2C905B2957248F008D8C7E /* SettingsEntryNavigate.m */,
 				5A2C9054295723D6008D8C7E /* SettingsEntryAction.h */,
 				5A2C9055295723D6008D8C7E /* SettingsEntryAction.m */,
+				5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuth.h */,
+				5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */,
+				5AD1B2D1297C1F4D005CED4E /* SettingsEntryLink.h */,
+				5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */,
 				5AA72542294C618900D9889C /* SettingsGroup.h */,
 				5AA72543294C618900D9889C /* SettingsGroup.m */,
 				5A78A4EA29573040007749F3 /* SettingsGroupSelect.h */,
@@ -1693,6 +1709,7 @@
 			children = (
 				5A78A4EE29587549007749F3 /* SettingsViewController.h */,
 				5A78A4EF29587549007749F3 /* SettingsViewController.m */,
+				5AD1B2D4297C3AC9005CED4E /* SettingsBaseTableViewCell */,
 				5AD1B2BE2972D2DF005CED4E /* SettingsActionTableViewCell */,
 				5AD1B2C62972D325005CED4E /* SettingsSelectTableViewCell */,
 				5AD1B2C22972D309005CED4E /* SettingsToggleTableViewCell */,
@@ -1847,6 +1864,17 @@
 				5AD1B2CC2972D353005CED4E /* SettingsNavigateTableViewCell.m */,
 			);
 			path = SettingsNavigateTableViewCell;
+			sourceTree = "<group>";
+		};
+		5AD1B2D4297C3AC9005CED4E /* SettingsBaseTableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+				5AD1B2D5297C3AF8005CED4E /* SettingsBaseTableViewCell.h */,
+				5AD1B2D6297C3AF8005CED4E /* SettingsBaseTableViewCell.m */,
+				5AB6CED8297DA7A800C71366 /* SettingsBaseTableViewCellConfig.h */,
+				5AB6CED9297DA7A800C71366 /* SettingsBaseTableViewCellConfig.m */,
+			);
+			path = SettingsBaseTableViewCell;
 			sourceTree = "<group>";
 		};
 		5AD347DD2837B28100235E96 /* bridges */ = {
@@ -2473,6 +2501,7 @@
 				5A29148B26E4F7AB004AD6F3 /* UIButtonWithFeedback.m in Sources */,
 				5A6DC5BF2659268700A2D37B /* CacheService.m in Sources */,
 				5A5E2AFD27524E7200A20489 /* NoDataView.m in Sources */,
+				5AB6CEDA297DA7A800C71366 /* SettingsBaseTableViewCellConfig.m in Sources */,
 				5A775B2B26064C9000CEFC78 /* StoredSearchItem+CoreDataClass.m in Sources */,
 				5ADD30EA26AB200300551408 /* IconNameToAnalyticsEvent.m in Sources */,
 				5A6DC5D2265AAB3900A2D37B /* RoutesSheetController.m in Sources */,
@@ -2509,6 +2538,7 @@
 				5A21445C2663E9A700582901 /* AlertUtils.m in Sources */,
 				5AC2C2A3263EC2E700CCBE63 /* BottomSheetView.m in Sources */,
 				5A775B1D26064C9000CEFC78 /* StoredRelatedItemUUID+CoreDataProperties.m in Sources */,
+				5AD1B2D3297C1F4D005CED4E /* SettingsEntryLink.m in Sources */,
 				5EA9409528E6175400E90014 /* UserSettingsTableViewCell.m in Sources */,
 				5A775B5426064C9000CEFC78 /* DetailsModel.m in Sources */,
 				5AB4AFB627B0311800C74857 /* InformationReference.m in Sources */,
@@ -2530,6 +2560,7 @@
 				5A9D707226EE7F4200F4799D /* BottomSheetViewDetailedMap.m in Sources */,
 				5A775E0826077A7D00CEFC78 /* DescriptionView.m in Sources */,
 				5A775B9026064C9000CEFC78 /* StyleUtils.m in Sources */,
+				5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuth.m in Sources */,
 				5A775B5F26064C9000CEFC78 /* IconNameToImageNameMap.m in Sources */,
 				5A775B8E26064C9000CEFC78 /* SizeUtils.m in Sources */,
 				5A6685E2285A36AC008E193E /* ResetPasswordEMailViewController.m in Sources */,
@@ -2600,6 +2631,7 @@
 				5A775B5326064C9000CEFC78 /* MapModel.m in Sources */,
 				5A6DC5052655B1DA00A2D37B /* StoredArea+CoreDataClass.m in Sources */,
 				5A2C989C29520FEE007A822F /* SettingsController.m in Sources */,
+				5AD1B2D7297C3AF8005CED4E /* SettingsBaseTableViewCell.m in Sources */,
 				5A29148726E3B893004AD6F3 /* UIButtonHighlightable.m in Sources */,
 				5A775B4E26064C9000CEFC78 /* LocationModel.m in Sources */,
 				5A775DF926077A7D00CEFC78 /* PlacesTableViewCellConstants.m in Sources */,

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -2240,9 +2240,9 @@
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = NWSTPFC433;
+						DevelopmentTeam = 53APD5F9YQ;
 						LastSwiftMigration = 1130;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -2750,10 +2750,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 26;
-				DEVELOPMENT_TEAM = NWSTPFC433;
+				DEVELOPMENT_TEAM = 53APD5F9YQ;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 53APD5F9YQ;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -2773,9 +2774,10 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.greentravel.radzima1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.greentravel.radzima;
 				PRODUCT_NAME = "Radzima Dev";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "EPM_SLR_In-House";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "EPM_SLR_In-House";
 				SWIFT_OBJC_BRIDGING_HEADER = "greenTravel-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 		5AD1B2C52972D319005CED4E /* SettingsToggleTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2C42972D319005CED4E /* SettingsToggleTableViewCell.m */; };
 		5AD1B2C92972D33E005CED4E /* SettingsSelectTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2C82972D33E005CED4E /* SettingsSelectTableViewCell.m */; };
 		5AD1B2CD2972D353005CED4E /* SettingsNavigateTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2CC2972D353005CED4E /* SettingsNavigateTableViewCell.m */; };
-		5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */; };
+		5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.m */; };
 		5AD1B2D3297C1F4D005CED4E /* SettingsEntryLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */; };
 		5AD1B2D7297C3AF8005CED4E /* SettingsBaseTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1B2D6297C3AF8005CED4E /* SettingsBaseTableViewCell.m */; };
 		5AD1F3842948C7F400ED288D /* SettingsEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD1F3832948C7E900ED288D /* SettingsEntry.m */; };
@@ -222,6 +222,9 @@
 		5AD6BF1A26C030B100DD3F2B /* AnalyticsTimeTracer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD6BF1926C030B100DD3F2B /* AnalyticsTimeTracer.m */; };
 		5AD71D9D274D5CDA00F205AD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5AD71D9F274D5CDA00F205AD /* InfoPlist.strings */; };
 		5ADBAC3F27243A7D0006A8C1 /* Typography.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADBAC3E27243A7D0006A8C1 /* Typography.m */; };
+		5ADCF6032980452A0005B06A /* SettingsEntryAuthLoggedIn.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADCF6022980452A0005B06A /* SettingsEntryAuthLoggedIn.m */; };
+		5ADCF6082981806B0005B06A /* AuthLoggedInTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADCF6072981806B0005B06A /* AuthLoggedInTableViewCell.m */; };
+		5ADCF60B298180800005B06A /* AuthLoggedOutTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADCF60A298180800005B06A /* AuthLoggedOutTableViewCell.m */; };
 		5ADD30CD26A6E2C900551408 /* UserDefaultsServiceConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADD30CC26A6E2BC00551408 /* UserDefaultsServiceConstants.m */; };
 		5ADD30EA26AB200300551408 /* IconNameToAnalyticsEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADD30E926AB200300551408 /* IconNameToAnalyticsEvent.m */; };
 		5ADF034B283CED3200D98E9A /* UserState.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ADF034A283CED3200D98E9A /* UserState.m */; };
@@ -645,8 +648,8 @@
 		5AD1B2C82972D33E005CED4E /* SettingsSelectTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsSelectTableViewCell.m; sourceTree = "<group>"; };
 		5AD1B2CB2972D353005CED4E /* SettingsNavigateTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsNavigateTableViewCell.h; sourceTree = "<group>"; };
 		5AD1B2CC2972D353005CED4E /* SettingsNavigateTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsNavigateTableViewCell.m; sourceTree = "<group>"; };
-		5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryAuth.h; sourceTree = "<group>"; };
-		5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryAuth.m; sourceTree = "<group>"; };
+		5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryAuthLoggedOut.h; sourceTree = "<group>"; };
+		5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryAuthLoggedOut.m; sourceTree = "<group>"; };
 		5AD1B2D1297C1F4D005CED4E /* SettingsEntryLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryLink.h; sourceTree = "<group>"; };
 		5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryLink.m; sourceTree = "<group>"; };
 		5AD1B2D5297C3AF8005CED4E /* SettingsBaseTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsBaseTableViewCell.h; sourceTree = "<group>"; };
@@ -678,6 +681,12 @@
 		5AD71DA0274D5CE000F205AD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5ADBAC3D27243A7D0006A8C1 /* Typography.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Typography.h; sourceTree = "<group>"; };
 		5ADBAC3E27243A7D0006A8C1 /* Typography.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Typography.m; sourceTree = "<group>"; };
+		5ADCF6012980452A0005B06A /* SettingsEntryAuthLoggedIn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryAuthLoggedIn.h; sourceTree = "<group>"; };
+		5ADCF6022980452A0005B06A /* SettingsEntryAuthLoggedIn.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryAuthLoggedIn.m; sourceTree = "<group>"; };
+		5ADCF6062981806B0005B06A /* AuthLoggedInTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuthLoggedInTableViewCell.h; sourceTree = "<group>"; };
+		5ADCF6072981806B0005B06A /* AuthLoggedInTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AuthLoggedInTableViewCell.m; sourceTree = "<group>"; };
+		5ADCF609298180800005B06A /* AuthLoggedOutTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuthLoggedOutTableViewCell.h; sourceTree = "<group>"; };
+		5ADCF60A298180800005B06A /* AuthLoggedOutTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AuthLoggedOutTableViewCell.m; sourceTree = "<group>"; };
 		5ADD30CB26A6E29F00551408 /* UserDefaultsServiceConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserDefaultsServiceConstants.h; sourceTree = "<group>"; };
 		5ADD30CC26A6E2BC00551408 /* UserDefaultsServiceConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserDefaultsServiceConstants.m; sourceTree = "<group>"; };
 		5ADD30E826AB200300551408 /* IconNameToAnalyticsEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IconNameToAnalyticsEvent.h; sourceTree = "<group>"; };
@@ -842,8 +851,10 @@
 				5A2C905B2957248F008D8C7E /* SettingsEntryNavigate.m */,
 				5A2C9054295723D6008D8C7E /* SettingsEntryAction.h */,
 				5A2C9055295723D6008D8C7E /* SettingsEntryAction.m */,
-				5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuth.h */,
-				5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuth.m */,
+				5AD1B2CE297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.h */,
+				5AD1B2CF297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.m */,
+				5ADCF6012980452A0005B06A /* SettingsEntryAuthLoggedIn.h */,
+				5ADCF6022980452A0005B06A /* SettingsEntryAuthLoggedIn.m */,
 				5AD1B2D1297C1F4D005CED4E /* SettingsEntryLink.h */,
 				5AD1B2D2297C1F4D005CED4E /* SettingsEntryLink.m */,
 				5AA72542294C618900D9889C /* SettingsGroup.h */,
@@ -1707,6 +1718,8 @@
 		5A78A4ED295873C5007749F3 /* SettingsViewController */ = {
 			isa = PBXGroup;
 			children = (
+				5ADCF60529817AEF0005B06A /* AuthLoggedInTableViewCell */,
+				5ADCF60429817A4F0005B06A /* AuthLoggedOutTableViewCell */,
 				5A78A4EE29587549007749F3 /* SettingsViewController.h */,
 				5A78A4EF29587549007749F3 /* SettingsViewController.m */,
 				5AD1B2D4297C3AC9005CED4E /* SettingsBaseTableViewCell */,
@@ -1937,6 +1950,24 @@
 				5AD347EE2837FD2800235E96 /* SignUpFormView.m */,
 			);
 			path = SignUpFormView;
+			sourceTree = "<group>";
+		};
+		5ADCF60429817A4F0005B06A /* AuthLoggedOutTableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+				5ADCF609298180800005B06A /* AuthLoggedOutTableViewCell.h */,
+				5ADCF60A298180800005B06A /* AuthLoggedOutTableViewCell.m */,
+			);
+			path = AuthLoggedOutTableViewCell;
+			sourceTree = "<group>";
+		};
+		5ADCF60529817AEF0005B06A /* AuthLoggedInTableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+				5ADCF6062981806B0005B06A /* AuthLoggedInTableViewCell.h */,
+				5ADCF6072981806B0005B06A /* AuthLoggedInTableViewCell.m */,
+			);
+			path = AuthLoggedInTableViewCell;
 			sourceTree = "<group>";
 		};
 		5ADF034C283D1C2700D98E9A /* AuthService */ = {
@@ -2511,6 +2542,7 @@
 				5A775E0026077A7D00CEFC78 /* FilterOption.m in Sources */,
 				5A775E1026077A7D00CEFC78 /* BannerView.m in Sources */,
 				5A775E0326077A7D00CEFC78 /* CategoriesFilterView.m in Sources */,
+				5ADCF60B298180800005B06A /* AuthLoggedOutTableViewCell.m in Sources */,
 				5A775B5226064C9000CEFC78 /* FeedModel.m in Sources */,
 				5ACC9A9E283969F7008E302D /* SecureTextField.m in Sources */,
 				5A5E2B05275CE3AB00A20489 /* ZoomableImageCollectionViewCell.m in Sources */,
@@ -2523,6 +2555,7 @@
 				5AB4AFD527C27B2B00C74857 /* DetailsScreenController.m in Sources */,
 				5AA72544294C618900D9889C /* SettingsGroup.m in Sources */,
 				5A775E1326077A7D00CEFC78 /* UISearchBarNoCancel.m in Sources */,
+				5ADCF6032980452A0005B06A /* SettingsEntryAuthLoggedIn.m in Sources */,
 				5AD6BF1526BEACA000DD3F2B /* AnalyticsUIScrollViewDelegate.m in Sources */,
 				5A78A4E929572E72007749F3 /* SettingsEntrySelect.m in Sources */,
 				5A8EB19D264E7DB000333F1E /* BaseMapViewController.m in Sources */,
@@ -2560,7 +2593,7 @@
 				5A9D707226EE7F4200F4799D /* BottomSheetViewDetailedMap.m in Sources */,
 				5A775E0826077A7D00CEFC78 /* DescriptionView.m in Sources */,
 				5A775B9026064C9000CEFC78 /* StyleUtils.m in Sources */,
-				5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuth.m in Sources */,
+				5AD1B2D0297C1DD2005CED4E /* SettingsEntryAuthLoggedOut.m in Sources */,
 				5A775B5F26064C9000CEFC78 /* IconNameToImageNameMap.m in Sources */,
 				5A775B8E26064C9000CEFC78 /* SizeUtils.m in Sources */,
 				5A6685E2285A36AC008E193E /* ResetPasswordEMailViewController.m in Sources */,
@@ -2587,6 +2620,7 @@
 				5AB4AFD227B5B20E00C74857 /* StoredInformationReference+CoreDataProperties.m in Sources */,
 				5A775B2126064C9000CEFC78 /* StoredRelatedItemUUID+CoreDataClass.m in Sources */,
 				5AB4AFD027B5B20E00C74857 /* StoredInformationReference+CoreDataClass.m in Sources */,
+				5ADCF6082981806B0005B06A /* AuthLoggedInTableViewCell.m in Sources */,
 				5A775E1526077A7D00CEFC78 /* SearchCell.m in Sources */,
 				5A775DF626077A7D00CEFC78 /* BookmarkCell.m in Sources */,
 				5A775B5826064C9000CEFC78 /* CategoryUUIDToRelatedItemUUIDs.m in Sources */,

--- a/ios/greenTravel.xcodeproj/project.pbxproj
+++ b/ios/greenTravel.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		5A246ACA26429689003C6E5B /* BookmarkButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A246AC926429689003C6E5B /* BookmarkButton.m */; };
 		5A29148726E3B893004AD6F3 /* UIButtonHighlightable.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A29148626E3B893004AD6F3 /* UIButtonHighlightable.m */; };
 		5A29148B26E4F7AB004AD6F3 /* UIButtonWithFeedback.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A29148A26E4F7AB004AD6F3 /* UIButtonWithFeedback.m */; };
+		5A295C262989388A00A109F0 /* SettingsAuthTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A295C252989388A00A109F0 /* SettingsAuthTableViewCell.m */; };
 		5A2C9056295723D6008D8C7E /* SettingsEntryAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A2C9055295723D6008D8C7E /* SettingsEntryAction.m */; };
 		5A2C90592957244D008D8C7E /* SettingsScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A2C90582957244D008D8C7E /* SettingsScreen.m */; };
 		5A2C905C2957248F008D8C7E /* SettingsEntryNavigate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A2C905B2957248F008D8C7E /* SettingsEntryNavigate.m */; };
@@ -316,6 +317,8 @@
 		5A29148926E4F7AB004AD6F3 /* UIButtonWithFeedback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIButtonWithFeedback.h; sourceTree = "<group>"; };
 		5A29148A26E4F7AB004AD6F3 /* UIButtonWithFeedback.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIButtonWithFeedback.m; sourceTree = "<group>"; };
 		5A29148D26E5031D004AD6F3 /* BookmarkButtonConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookmarkButtonConstants.h; sourceTree = "<group>"; };
+		5A295C242989388A00A109F0 /* SettingsAuthTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsAuthTableViewCell.h; sourceTree = "<group>"; };
+		5A295C252989388A00A109F0 /* SettingsAuthTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsAuthTableViewCell.m; sourceTree = "<group>"; };
 		5A2C9054295723D6008D8C7E /* SettingsEntryAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsEntryAction.h; sourceTree = "<group>"; };
 		5A2C9055295723D6008D8C7E /* SettingsEntryAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsEntryAction.m; sourceTree = "<group>"; };
 		5A2C90572957244D008D8C7E /* SettingsScreen.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsScreen.h; sourceTree = "<group>"; };
@@ -957,6 +960,15 @@
 				5A29148A26E4F7AB004AD6F3 /* UIButtonWithFeedback.m */,
 			);
 			path = UIButtonWithFeedback;
+			sourceTree = "<group>";
+		};
+		5A295C23298937B900A109F0 /* SettingsAuthTableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+				5A295C242989388A00A109F0 /* SettingsAuthTableViewCell.h */,
+				5A295C252989388A00A109F0 /* SettingsAuthTableViewCell.m */,
+			);
+			path = SettingsAuthTableViewCell;
 			sourceTree = "<group>";
 		};
 		5A2C989929520FD8007A822F /* SettingsController */ = {
@@ -1718,6 +1730,7 @@
 		5A78A4ED295873C5007749F3 /* SettingsViewController */ = {
 			isa = PBXGroup;
 			children = (
+				5A295C23298937B900A109F0 /* SettingsAuthTableViewCell */,
 				5ADCF60529817AEF0005B06A /* AuthLoggedInTableViewCell */,
 				5ADCF60429817A4F0005B06A /* AuthLoggedOutTableViewCell */,
 				5A78A4EE29587549007749F3 /* SettingsViewController.h */,
@@ -2545,6 +2558,7 @@
 				5ADCF60B298180800005B06A /* AuthLoggedOutTableViewCell.m in Sources */,
 				5A775B5226064C9000CEFC78 /* FeedModel.m in Sources */,
 				5ACC9A9E283969F7008E302D /* SecureTextField.m in Sources */,
+				5A295C262989388A00A109F0 /* SettingsAuthTableViewCell.m in Sources */,
 				5A5E2B05275CE3AB00A20489 /* ZoomableImageCollectionViewCell.m in Sources */,
 				5A775B5B26064C9000CEFC78 /* PathItem.m in Sources */,
 				5A775B2226064C9000CEFC78 /* StoredSearchItem+CoreDataProperties.m in Sources */,

--- a/ios/models/SettingsModel/SettingsEntry.h
+++ b/ios/models/SettingsModel/SettingsEntry.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSUUID *uid;
 @property (strong, nonatomic) NSString *name;
+@property (strong, nonatomic) NSString *value;
+@property (assign, nonatomic) BOOL chevron;
+@property (strong, nonatomic) NSString *iconName;
 @property (weak, nonatomic) SettingsGroup *parentGroup;
 
 - (instancetype)initWithName:(NSString *)name

--- a/ios/models/SettingsModel/SettingsEntryAuth.h
+++ b/ios/models/SettingsModel/SettingsEntryAuth.h
@@ -1,0 +1,16 @@
+//
+//  SettingsEntryAuth.h
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import "SettingsEntry.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsEntryAuth : SettingsEntry
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsEntryAuth.m
+++ b/ios/models/SettingsModel/SettingsEntryAuth.m
@@ -1,0 +1,12 @@
+//
+//  SettingsEntryAuth.m
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import "SettingsEntryAuth.h"
+
+@implementation SettingsEntryAuth
+
+@end

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.h
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SettingsEntryAuthLoggedIn : SettingsEntryNavigate
 
+@property (assign, nonatomic) BOOL inProgress;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.h
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.h
@@ -1,0 +1,16 @@
+//
+//  SettingsEntryAuthLoggedIn.h
+//  greenTravel
+//
+//  Created by Alex K on 24.01.23.
+//
+
+#import "SettingsEntryNavigate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsEntryAuthLoggedIn : SettingsEntryNavigate
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.m
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedIn.m
@@ -1,0 +1,12 @@
+//
+//  SettingsEntryAuthLoggedIn.m
+//  greenTravel
+//
+//  Created by Alex K on 24.01.23.
+//
+
+#import "SettingsEntryAuthLoggedIn.h"
+
+@implementation SettingsEntryAuthLoggedIn
+
+@end

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.h
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SettingsEntryAuthLoggedOut : SettingsEntryAction
 
+@property (assign, nonatomic) BOOL inProgress;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.h
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.h
@@ -5,11 +5,11 @@
 //  Created by Alex K on 21.01.23.
 //
 
-#import "SettingsEntry.h"
+#import "SettingsEntryAction.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SettingsEntryAuth : SettingsEntry
+@interface SettingsEntryAuthLoggedOut : SettingsEntryAction
 
 @end
 

--- a/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.m
+++ b/ios/models/SettingsModel/SettingsEntryAuthLoggedOut.m
@@ -5,8 +5,8 @@
 //  Created by Alex K on 21.01.23.
 //
 
-#import "SettingsEntryAuth.h"
+#import "SettingsEntryAuthLoggedOut.h"
 
-@implementation SettingsEntryAuth
+@implementation SettingsEntryAuthLoggedOut
 
 @end

--- a/ios/models/SettingsModel/SettingsEntryLink.h
+++ b/ios/models/SettingsModel/SettingsEntryLink.h
@@ -1,0 +1,16 @@
+//
+//  SettingsEntryLink.h
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import "SettingsEntry.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsEntryLink : SettingsEntry
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsEntryLink.m
+++ b/ios/models/SettingsModel/SettingsEntryLink.m
@@ -1,0 +1,12 @@
+//
+//  SettingsEntryLink.m
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import "SettingsEntryLink.h"
+
+@implementation SettingsEntryLink
+
+@end

--- a/ios/models/SettingsModel/SettingsEntryNavigate.h
+++ b/ios/models/SettingsModel/SettingsEntryNavigate.h
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) SettingsScreen *screen;
 
-- (instancetype)init;
 - (instancetype)initWithName:(NSString *)name
                  parentGroup:(SettingsGroup *)parentGroup
                       screen:(SettingsScreen *)screen;

--- a/ios/models/SettingsModel/SettingsEntryNavigate.h
+++ b/ios/models/SettingsModel/SettingsEntryNavigate.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) SettingsScreen *screen;
 
+- (instancetype)init;
 - (instancetype)initWithName:(NSString *)name
                  parentGroup:(SettingsGroup *)parentGroup
                       screen:(SettingsScreen *)screen;

--- a/ios/models/SettingsModel/SettingsEntryNavigate.m
+++ b/ios/models/SettingsModel/SettingsEntryNavigate.m
@@ -9,12 +9,6 @@
 
 @implementation SettingsEntryNavigate
 
-- (instancetype)init {
-  if (self = [super init]) {
-    [super setChevron:YES];
-  }
-  return self;
-}
 - (instancetype)initWithName:(NSString *)name
                  parentGroup:(SettingsGroup *)parentGroup
                       screen:(SettingsScreen *)screen {

--- a/ios/models/SettingsModel/SettingsEntryNavigate.m
+++ b/ios/models/SettingsModel/SettingsEntryNavigate.m
@@ -9,12 +9,19 @@
 
 @implementation SettingsEntryNavigate
 
+- (instancetype)init {
+  if (self = [super init]) {
+    [super setChevron:YES];
+  }
+  return self;
+}
 - (instancetype)initWithName:(NSString *)name
                  parentGroup:(SettingsGroup *)parentGroup
                       screen:(SettingsScreen *)screen {
   if (self = [super initWithName:name parentGroup:parentGroup]) {
     _screen = screen;
   }
+  self.chevron = YES;
   return self;
 }
 

--- a/ios/models/SettingsModel/SettingsGroup.h
+++ b/ios/models/SettingsModel/SettingsGroup.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic) NSUUID *uid;
 @property (strong, nonatomic) NSString *name;
-@property (strong, nonatomic) NSArray<SettingsEntry *> *entries;
+@property (strong, nonatomic) NSMutableArray<SettingsEntry *> *entries;
 
 - (instancetype)initWithName:(NSString *)name
                      entries:(NSArray<SettingsEntry *>*)entries;

--- a/ios/models/SettingsModel/SettingsGroup.m
+++ b/ios/models/SettingsModel/SettingsGroup.m
@@ -13,7 +13,7 @@
 - (instancetype)initWithName:(NSString *)name
                      entries:(NSArray<SettingsEntry *>*)entries {
   if (self = [super init]) {
-    _entries = entries;
+    _entries = [[NSMutableArray alloc] initWithArray:entries];
     _name = name;
   }
   return self;

--- a/ios/models/SettingsModel/SettingsModel.h
+++ b/ios/models/SettingsModel/SettingsModel.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
                              userModel:(UserModel *)userModel;
 - (void)updateEntry:(SettingsEntry *)updatedEntry;
 - (void)updateGroup:(SettingsGroup *)updatedGroup;
+- (void)updateScreen:(SettingsScreen *)updatedScreen;
 - (SettingsScreen *)findScreenByID:(NSUUID *)uuid;
 
 @end

--- a/ios/models/SettingsModel/SettingsModel.m
+++ b/ios/models/SettingsModel/SettingsModel.m
@@ -8,18 +8,13 @@
 #import "SettingsModel.h"
 #import "SettingsModelObserver.h"
 #import "SettingsGroup.h"
-#import "SettingsEntry.h"
-#import "SettingsScreen.h"
-#import "SettingsEntryAction.h"
-#import "SettingsEntryAuthLoggedOut.h"
-#import "SettingsEntryAuthLoggedIn.h"
 #import "SettingsEntryNavigate.h"
-#import "SettingsScreen.h"
+#import "SettingsScreenRoot.h"
 #import "UserModel.h"
 #import <UIKit/UIKit.h>
 #import "ProfileTableViewController.h"
 #import "LoginViewController.h"
-#import <SDWebImage/SDWebImage.h>
+
 #import "SettingsViewController.h"
 
 @interface SettingsModel()
@@ -46,69 +41,8 @@
 }
 
 - (void)setUp {
-#pragma mark - Auth group
-  SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
-  authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
-  __weak typeof(self) weakSelf = self;
-  authEntry.doAction = ^void(UIViewController *activeViewController) {
-    LoginViewController *loginViewController =
-    [[LoginViewController alloc] initWithController:weakSelf.userController
-                                              model:weakSelf.userModel];
-    loginViewController.title = NSLocalizedString(@"LogInTitle", @"");
-    UINavigationController *loginViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:loginViewController];
-    if (@available(iOS 13.0, *)) {
-      [loginViewControllerWithNavigation setModalInPresentation:YES];
-    }
-    [activeViewController presentViewController:loginViewControllerWithNavigation animated:YES completion:^{}];
-  };
-  
-  SettingsGroup *authGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[authEntry]];
-#pragma mark - General group
-  SettingsEntryAction *languageEntry = [SettingsEntryAction new];
-  languageEntry.name = NSLocalizedString(@"Language", @"");
-  languageEntry.doAction = ^void(UIViewController *activeViewController) {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                                       options:@{} completionHandler:^(BOOL success) {}];
-  };
-  
-  SettingsEntryAction *clearCacheEntry = [SettingsEntryAction new];
-  clearCacheEntry.name = NSLocalizedString(@"Language", @"");
-  clearCacheEntry.doAction = ^void(UIViewController *activeViewController) {
-    UIAlertController *alert =
-    [UIAlertController alertControllerWithTitle:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageHeader", @"")
-                                        message:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageBody", @"")
-                                 preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertCancel", @"") style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action){}]];
-    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertOK", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-      [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{}];
-    }]];
-    [activeViewController presentViewController:alert animated:YES completion:^{}];
-  };
-  SettingsGroup *generalGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[languageEntry, clearCacheEntry]];
-#pragma mark - About group
-  SettingsEntryAction *aboutTextEntry = [SettingsEntryAction new];
-  aboutTextEntry.name = NSLocalizedString(@"Language", @"");
-  aboutTextEntry.doAction = ^void(UIViewController *activeViewController) {};
-  
-  SettingsGroup *aboutTextGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutTextEntry]];
-  
-  SettingsScreen *screenAbout = [SettingsScreen new];
-  screenAbout.name = @"";
-  screenAbout.groups = [[NSMutableArray alloc] initWithArray:@[aboutTextGroup]];
-  
-  SettingsEntryNavigate *aboutEntry = [SettingsEntryNavigate new];
-  aboutEntry.name = NSLocalizedString(@"Language", @"");
-  aboutEntry.screen = [SettingsScreen new];
-  
-  SettingsGroup *aboutGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutEntry]];
-  
 #pragma mark - Assembling to root
-  self.tree.groups =
-  [[NSMutableArray alloc] initWithArray:@[authGroup, generalGroup, aboutGroup]];
+  self.tree = [[SettingsScreenRoot alloc] initWithUserController:self.userController userModel:self.userModel];
 }
 
 - (void)updateEntry:(SettingsEntry *)updatedEntry

--- a/ios/models/SettingsModel/SettingsModel.m
+++ b/ios/models/SettingsModel/SettingsModel.m
@@ -20,6 +20,7 @@
 #import "ProfileTableViewController.h"
 #import "LoginViewController.h"
 #import <SDWebImage/SDWebImage.h>
+#import "SettingsViewController.h"
 
 @interface SettingsModel()
 
@@ -48,11 +49,11 @@
 #pragma mark - Auth group
   SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
   authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  __weak typeof(self) weakSelf = self;
   authEntry.doAction = ^void(UIViewController *activeViewController) {
-    ProfileTableViewController *profileTableViewController = (ProfileTableViewController *)activeViewController;
     LoginViewController *loginViewController =
-    [[LoginViewController alloc] initWithController:profileTableViewController.userController
-                                              model:profileTableViewController.userModel];
+    [[LoginViewController alloc] initWithController:weakSelf.userController
+                                              model:weakSelf.userModel];
     loginViewController.title = NSLocalizedString(@"LogInTitle", @"");
     UINavigationController *loginViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:loginViewController];
     if (@available(iOS 13.0, *)) {

--- a/ios/models/SettingsModel/SettingsModel.m
+++ b/ios/models/SettingsModel/SettingsModel.m
@@ -39,6 +39,7 @@
                                           groups:@[]];
     _userModel = userModel;
     _userController = userController;
+    [self setUp];
   }
   return self;
 }
@@ -95,7 +96,7 @@
   
   SettingsScreen *screenAbout = [SettingsScreen new];
   screenAbout.name = @"";
-  screenAbout.groups = @[aboutTextGroup];
+  screenAbout.groups = [[NSMutableArray alloc] initWithArray:@[aboutTextGroup]];
   
   SettingsEntryNavigate *aboutEntry = [SettingsEntryNavigate new];
   aboutEntry.name = NSLocalizedString(@"Language", @"");

--- a/ios/models/SettingsModel/SettingsModel.m
+++ b/ios/models/SettingsModel/SettingsModel.m
@@ -167,7 +167,8 @@
   return [self findScreenByID:(NSUUID *)uuid forTree:self.tree];
 }
 
-- (void)onUserModelStateTransitionFrom:(UserModelState)prevState toCurrentState:(UserModelState)currentState {
+- (void)onUserModelStateTransitionFrom:(UserModelState)prevState
+                        toCurrentState:(UserModelState)currentState {
 }
 
 @end

--- a/ios/models/SettingsModel/SettingsModelObserver.h
+++ b/ios/models/SettingsModel/SettingsModelObserver.h
@@ -11,12 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SettingsGroup;
 @class SettingsEntry;
+@class SettingsScreen;
 
 @protocol SettingsModelObserver <NSObject>
 
 - (void)onSettingsModelTreeChange:(NSMutableArray<SettingsGroup *> *) tree;
 - (void)onSettingsModelEntryChange:(SettingsEntry *)entry;
 - (void)onSettingsModelGroupChange:(SettingsGroup *)group;
+- (void)onSettingsModelScreenChange:(SettingsScreen *)screen;
 
 @end
 

--- a/ios/models/SettingsModel/SettingsScreen.h
+++ b/ios/models/SettingsModel/SettingsScreen.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSUUID *uid;
 @property (strong, nonatomic) NSString *name;
-@property (strong, nonatomic) NSArray<SettingsGroup *> *groups;
+@property (strong, nonatomic) NSMutableArray<SettingsGroup *> *groups;
 
 - (instancetype)initWithName:(NSString *)name
                      groups:(NSArray<SettingsGroup *>*)groups;

--- a/ios/models/SettingsModel/SettingsScreenRoot.h
+++ b/ios/models/SettingsModel/SettingsScreenRoot.h
@@ -1,0 +1,23 @@
+//
+//  SettingsScreenRoot.h
+//  greenTravel
+//
+//  Created by Alex K on 8.02.23.
+//
+
+#import "SettingsScreen.h"
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class UserController;
+@class UserModel;
+
+@interface SettingsScreenRoot : SettingsScreen
+
+- (instancetype)initWithUserController:(UserController *)userController
+                             userModel:(UserModel *)userModel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsScreenRoot.h
+++ b/ios/models/SettingsModel/SettingsScreenRoot.h
@@ -18,6 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithUserController:(UserController *)userController
                              userModel:(UserModel *)userModel;
 
+- (void)startSignIn;
+- (void)finishSignIn;
+- (void)startSignOut;
+- (void)finishSignOut;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -56,18 +56,22 @@
   [[SettingsGroup alloc] initWithName:@"" entries:@[authEntry]];
 #pragma mark - General group
   SettingsEntryAction *languageEntry = [SettingsEntryAction new];
-  languageEntry.name = NSLocalizedString(@"Language", @"");
+  languageEntry.name = NSLocalizedString(@"SettingsViewControllerLanguageCellTitle", @"");
+  languageEntry.value = @"Русский";
+  languageEntry.chevron = YES;
+  languageEntry.iconName = @"language";
   languageEntry.doAction = ^void(UIViewController *activeViewController) {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
                                        options:@{} completionHandler:^(BOOL success) {}];
   };
   
   SettingsEntryAction *clearCacheEntry = [SettingsEntryAction new];
-  clearCacheEntry.name = NSLocalizedString(@"Language", @"");
+  clearCacheEntry.name = NSLocalizedString(@"SettingsViewControllerCacheCellTitle", @"");
+  clearCacheEntry.iconName = @"dataAndStorage";
   clearCacheEntry.doAction = ^void(UIViewController *activeViewController) {
     UIAlertController *alert =
-    [UIAlertController alertControllerWithTitle:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageHeader", @"")
-                                        message:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageBody", @"")
+    [UIAlertController alertControllerWithTitle:NSLocalizedString(@"SettingsViewControllerCacheAlertMessageHeader", @"")
+                                        message:NSLocalizedString(@"SettingsViewControllerCacheAlertMessageBody", @"")
                                  preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertCancel", @"") style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action){}]];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertOK", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -77,24 +81,17 @@
   };
   SettingsGroup *generalGroup =
   [[SettingsGroup alloc] initWithName:@"" entries:@[languageEntry, clearCacheEntry]];
-#pragma mark - About group
-  SettingsEntryAction *aboutTextEntry = [SettingsEntryAction new];
-  aboutTextEntry.name = NSLocalizedString(@"Language", @"");
-  aboutTextEntry.doAction = ^void(UIViewController *activeViewController) {};
+#pragma mark - About group  
+  SettingsEntryNavigate *termsEntry = [SettingsEntryNavigate new];
+  termsEntry.name = NSLocalizedString(@"SettingsViewControllerTermsCellTitle", @"");
+  termsEntry.screen = [SettingsScreen new];
   
-  SettingsGroup *aboutTextGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutTextEntry]];
-  
-  SettingsScreen *screenAbout = [SettingsScreen new];
-  screenAbout.name = @"";
-  screenAbout.groups = [[NSMutableArray alloc] initWithArray:@[aboutTextGroup]];
-  
-  SettingsEntryNavigate *aboutEntry = [SettingsEntryNavigate new];
-  aboutEntry.name = NSLocalizedString(@"Language", @"");
-  aboutEntry.screen = [SettingsScreen new];
+  SettingsEntryNavigate *privacyEntry = [SettingsEntryNavigate new];
+  privacyEntry.name = NSLocalizedString(@"SettingsViewControllerPrivacyCellTitle", @"");
+  privacyEntry.screen = [SettingsScreen new];
   
   SettingsGroup *aboutGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutEntry]];
+  [[SettingsGroup alloc] initWithName:@"" entries:@[termsEntry, privacyEntry]];
   
 #pragma mark - Assembling to root
   self.groups =

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -1,0 +1,104 @@
+//
+//  SettingsScreenRoot.m
+//  greenTravel
+//
+//  Created by Alex K on 8.02.23.
+//
+
+#import "SettingsScreenRoot.h"
+#import "UserModel.h"
+#import "UserController.h"
+#import "SettingsEntryAuthLoggedOut.h"
+#import "SettingsEntryAuthLoggedIn.h"
+#import "SettingsGroup.h"
+#import "SettingsEntry.h"
+#import "SettingsScreen.h"
+#import "LoginViewController.h"
+#import <SDWebImage/SDWebImage.h>
+
+@interface SettingsScreenRoot()
+
+@property (strong, nonatomic) UserModel *userModel;
+@property (strong, nonatomic) UserController *userController;
+
+@end
+
+@implementation SettingsScreenRoot
+
+- (instancetype)initWithUserController:(id)userController userModel:(id)userModel {
+  self = [super initWithName:@"root" groups:@[]];
+  if (self) {
+    _userModel = userModel;
+    _userController = userController;
+    [self setUp];
+  }
+  return self;
+}
+
+- (void)setUp {
+#pragma mark - Auth group
+  SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
+  authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  __weak typeof(self) weakSelf = self;
+  authEntry.doAction = ^void(UIViewController *activeViewController) {
+    LoginViewController *loginViewController =
+    [[LoginViewController alloc] initWithController:weakSelf.userController
+                                              model:weakSelf.userModel];
+    loginViewController.title = NSLocalizedString(@"LogInTitle", @"");
+    UINavigationController *loginViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:loginViewController];
+    if (@available(iOS 13.0, *)) {
+      [loginViewControllerWithNavigation setModalInPresentation:YES];
+    }
+    [activeViewController presentViewController:loginViewControllerWithNavigation animated:YES completion:^{}];
+  };
+  
+  SettingsGroup *authGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[authEntry]];
+#pragma mark - General group
+  SettingsEntryAction *languageEntry = [SettingsEntryAction new];
+  languageEntry.name = NSLocalizedString(@"Language", @"");
+  languageEntry.doAction = ^void(UIViewController *activeViewController) {
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                                       options:@{} completionHandler:^(BOOL success) {}];
+  };
+  
+  SettingsEntryAction *clearCacheEntry = [SettingsEntryAction new];
+  clearCacheEntry.name = NSLocalizedString(@"Language", @"");
+  clearCacheEntry.doAction = ^void(UIViewController *activeViewController) {
+    UIAlertController *alert =
+    [UIAlertController alertControllerWithTitle:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageHeader", @"")
+                                        message:NSLocalizedString(@"ProfileTableViewAlertClearCacheMessageBody", @"")
+                                 preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertCancel", @"") style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action){}]];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"AlertOK", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+      [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{}];
+    }]];
+    [activeViewController presentViewController:alert animated:YES completion:^{}];
+  };
+  SettingsGroup *generalGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[languageEntry, clearCacheEntry]];
+#pragma mark - About group
+  SettingsEntryAction *aboutTextEntry = [SettingsEntryAction new];
+  aboutTextEntry.name = NSLocalizedString(@"Language", @"");
+  aboutTextEntry.doAction = ^void(UIViewController *activeViewController) {};
+  
+  SettingsGroup *aboutTextGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutTextEntry]];
+  
+  SettingsScreen *screenAbout = [SettingsScreen new];
+  screenAbout.name = @"";
+  screenAbout.groups = [[NSMutableArray alloc] initWithArray:@[aboutTextGroup]];
+  
+  SettingsEntryNavigate *aboutEntry = [SettingsEntryNavigate new];
+  aboutEntry.name = NSLocalizedString(@"Language", @"");
+  aboutEntry.screen = [SettingsScreen new];
+  
+  SettingsGroup *aboutGroup =
+  [[SettingsGroup alloc] initWithName:@"" entries:@[aboutEntry]];
+  
+#pragma mark - Assembling to root
+  self.groups =
+  [[NSMutableArray alloc] initWithArray:@[authGroup, generalGroup, aboutGroup]];
+}
+
+@end

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -40,6 +40,7 @@
 #pragma mark - Auth group
   SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
   authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  authEntry.inProgress = NO;
   __weak typeof(self) weakSelf = self;
   authEntry.doAction = ^void(UIViewController *activeViewController) {
     LoginViewController *loginViewController =
@@ -97,6 +98,23 @@
 #pragma mark - Assembling to root
   self.groups =
   [[NSMutableArray alloc] initWithArray:@[authGroup, generalGroup, aboutGroup]];
+}
+
+- (void)startSignIn {
+  SettingsEntryAuthLoggedOut *authEntry = (SettingsEntryAuthLoggedOut *)self.groups[0].entries[0];
+  authEntry.inProgress = YES;
+}
+
+- (void)finishSignIn {
+  SettingsScreen *screen = [SettingsScreen new];
+  screen.name = @"";
+  
+  
+  SettingsEntryAuthLoggedIn *authEntry = [SettingsEntryAuthLoggedIn new];
+  authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
+  authEntry.inProgress = NO;
+  __weak typeof(self) weakSelf = self;
+  authEntry.screen;
 }
 
 @end

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -93,7 +93,8 @@
     [activeViewController presentViewController:alert animated:YES completion:^{}];
   };
   SettingsGroup *generalGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[languageEntry, clearCacheEntry]];
+  [[SettingsGroup alloc] initWithName:NSLocalizedString(@"SettingsViewControllerGeneralGroupTitle", @"")
+                              entries:@[languageEntry, clearCacheEntry]];
   return generalGroup;
 }
 
@@ -108,7 +109,8 @@
   privacyEntry.screen = [SettingsScreen new];
   
   SettingsGroup *aboutGroup =
-  [[SettingsGroup alloc] initWithName:@"" entries:@[termsEntry, privacyEntry]];
+  [[SettingsGroup alloc] initWithName:NSLocalizedString(@"SettingsViewControllerAboutGroupTitle", @"")
+                              entries:@[termsEntry, privacyEntry]];
   return aboutGroup;
 }
 

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -36,8 +36,15 @@
   return self;
 }
 
+#pragma mark - Assembling to root
 - (void)setUp {
+  self.groups = [[NSMutableArray alloc] initWithArray:@[[self setUpAuthGroup],
+                                                        [self setUpGeneralGroup],
+                                                        [self setUpAboutGroup]]];
+}
+
 #pragma mark - Auth group
+- (SettingsGroup *)setUpAuthGroup {
   SettingsEntryAuthLoggedOut *authEntry = [SettingsEntryAuthLoggedOut new];
   authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
   authEntry.inProgress = NO;
@@ -56,7 +63,11 @@
   
   SettingsGroup *authGroup =
   [[SettingsGroup alloc] initWithName:@"" entries:@[authEntry]];
+  return authGroup;
+}
+
 #pragma mark - General group
+- (SettingsGroup *)setUpGeneralGroup {
   SettingsEntryAction *languageEntry = [SettingsEntryAction new];
   languageEntry.name = NSLocalizedString(@"SettingsViewControllerLanguageCellTitle", @"");
   languageEntry.value = getCurrentLocaleFriendlyName();
@@ -83,7 +94,11 @@
   };
   SettingsGroup *generalGroup =
   [[SettingsGroup alloc] initWithName:@"" entries:@[languageEntry, clearCacheEntry]];
-#pragma mark - About group  
+  return generalGroup;
+}
+
+#pragma mark - About group
+- (SettingsGroup *)setUpAboutGroup {
   SettingsEntryNavigate *termsEntry = [SettingsEntryNavigate new];
   termsEntry.name = NSLocalizedString(@"SettingsViewControllerTermsCellTitle", @"");
   termsEntry.screen = [SettingsScreen new];
@@ -94,10 +109,7 @@
   
   SettingsGroup *aboutGroup =
   [[SettingsGroup alloc] initWithName:@"" entries:@[termsEntry, privacyEntry]];
-  
-#pragma mark - Assembling to root
-  self.groups =
-  [[NSMutableArray alloc] initWithArray:@[authGroup, generalGroup, aboutGroup]];
+  return aboutGroup;
 }
 
 - (void)startSignIn {
@@ -113,8 +125,6 @@
   SettingsEntryAuthLoggedIn *authEntry = [SettingsEntryAuthLoggedIn new];
   authEntry.name = NSLocalizedString(@"ProfileScreenTitle", @"");
   authEntry.inProgress = NO;
-  __weak typeof(self) weakSelf = self;
-  authEntry.screen;
 }
 
 @end

--- a/ios/models/SettingsModel/SettingsScreenRoot.m
+++ b/ios/models/SettingsModel/SettingsScreenRoot.m
@@ -15,6 +15,7 @@
 #import "SettingsScreen.h"
 #import "LoginViewController.h"
 #import <SDWebImage/SDWebImage.h>
+#import "LocaleUtils.h"
 
 @interface SettingsScreenRoot()
 
@@ -57,7 +58,7 @@
 #pragma mark - General group
   SettingsEntryAction *languageEntry = [SettingsEntryAction new];
   languageEntry.name = NSLocalizedString(@"SettingsViewControllerLanguageCellTitle", @"");
-  languageEntry.value = @"Русский";
+  languageEntry.value = getCurrentLocaleFriendlyName();
   languageEntry.chevron = YES;
   languageEntry.iconName = @"language";
   languageEntry.doAction = ^void(UIViewController *activeViewController) {

--- a/ios/ru.lproj/Localizable.strings
+++ b/ios/ru.lproj/Localizable.strings
@@ -87,6 +87,7 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Авторизуйтесь или зарегистрируйтесь";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Дождитесь, пока идет проверка логина";
 
+"SettingsViewControllerGeneralGroupTitle" = "Настройки";
 "SettingsViewControllerLanguageCellTitle" = "Язык";
 "SettingsViewControllerLanguageCellValueEnglish" = "Английский";
 "SettingsViewControllerLanguageCellValueRussian" = "Русский";
@@ -96,6 +97,7 @@
 "SettingsViewControllerCacheAlertMessageHeader" = "Очистить кэш?";
 "SettingsViewControllerCacheAlertMessageBody" = "Это уменьшит размер приложения";
 
+"SettingsViewControllerAboutGroupTitle" = "Информация";
 "SettingsViewControllerTermsCellTitle" = "Условия использования";
 "SettingsViewControllerPrivacyCellTitle" = "Политика безопасности";
 

--- a/ios/ru.lproj/Localizable.strings
+++ b/ios/ru.lproj/Localizable.strings
@@ -79,6 +79,15 @@
 
 "ProfileTableViewCellSignedMainTitleLabel" = "Вы авторизованы";
 
+//SettingsViewController
+"SettingsViewControllerAuthCellTitleAuthorized" = "Вы авторизованы";
+"SettingsViewControllerAuthCellTitleAuthorizedNot" = "Вы не авторизованы";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Авторизация";
+
+"SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Авторизуйтесь или зарегистрируйтесь";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Дождитесь, пока идет проверка логина";
+
+
 "UserSettingsTableViewCellTermsOfUseMainLabel" = "Условия использования";
 "UserSettingsTableViewCellPrivacyPolicyMainLabel" = "Политика конфиденциальности";
 "UserSettingsTableViewCellLogOutMainLabel" = "Выйти";

--- a/ios/ru.lproj/Localizable.strings
+++ b/ios/ru.lproj/Localizable.strings
@@ -87,6 +87,17 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "Авторизуйтесь или зарегистрируйтесь";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "Дождитесь, пока идет проверка логина";
 
+"SettingsViewControllerLanguageCellTitle" = "Язык";
+"SettingsViewControllerLanguageCellValueEnglish" = "Английский";
+"SettingsViewControllerLanguageCellValueRussian" = "Русский";
+"SettingsViewControllerLanguageCellValueChineseSimplified" = "Китайский";
+
+"SettingsViewControllerCacheCellTitle" = "Очистить кэш";
+"SettingsViewControllerCacheAlertMessageHeader" = "Очистить кэш?";
+"SettingsViewControllerCacheAlertMessageBody" = "Это уменьшит размер приложения";
+
+"SettingsViewControllerTermsCellTitle" = "Условия использования";
+"SettingsViewControllerPrivacyCellTitle" = "Политика безопасности";
 
 "UserSettingsTableViewCellTermsOfUseMainLabel" = "Условия использования";
 "UserSettingsTableViewCellPrivacyPolicyMainLabel" = "Политика конфиденциальности";

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -199,6 +199,7 @@ static BOOL kSignUpEnabled = YES;
 
   self.profileControllerWithNavigation.tabBarItem = self.profileTabBarItem;
 #pragma mark - SettingsViewController
+  //TODO: will be enabled after completion of #603.
   if (/* DISABLES CODE */ (YES)) {
   	SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
     SettingsController *settingsController = [[SettingsController alloc] initWithModel:settingsModel userController:userController userModel:userModel];

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -65,6 +65,7 @@ static BOOL kSignUpEnabled = YES;
 @property (strong, nonatomic) UINavigationController *mapControllerWithNavigation;
 @property (strong, nonatomic) UINavigationController *bookmarksControllerWithNavigation;
 @property (strong, nonatomic) UINavigationController *profileControllerWithNavigation;
+@property (strong, nonatomic) UINavigationController *settingsViewControllerWithNavigation;
 
 @end
 
@@ -177,14 +178,28 @@ static BOOL kSignUpEnabled = YES;
     self.bookmarksControllerWithNavigation.navigationBar.titleTextAttributes =
     [TypographyLegacy get].navigationSemiboldAttributes;
 
+#pragma mark - ProfileRootViewController
+  ProfileTableViewController *profileTableViewController = [[ProfileTableViewController alloc] initWithController:userController model:userModel];
+  profileTableViewController.title = NSLocalizedString(@"ProfileTitle", @"");
+  profileTableViewController.bookmarksGroupModel = bookmarksGroupsModel;
+  profileTableViewController.indexModel = self.indexModel;
+  profileTableViewController.apiService = self.apiService;
+  profileTableViewController.coreDataService = self.coreDataService;
+  profileTableViewController.mapService = self.mapService;
+  profileTableViewController.mapModel = mapModel;
+  profileTableViewController.searchModel = searchModel;
+  profileTableViewController.detailsModel = detailsModel;
+  profileTableViewController.locationModel = locationModel;
+  self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:profileTableViewController];
 #pragma mark - SettingsViewController
-  SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
-  SettingsController *settingsController = [[SettingsController alloc] initWithModel:settingsModel userController:userController userModel:userModel];
+  if (/* DISABLES CODE */ (NO)) {
+  	SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
+    SettingsController *settingsController = [[SettingsController alloc] initWithModel:settingsModel userController:userController userModel:userModel];
 
-  SettingsViewController *settingsViewController = [[SettingsViewController alloc] initWithSettingsController:settingsController settingsModel:settingsModel];
-  settingsViewController.title = NSLocalizedString(@"ProfileTitle", @"");
-  
-  self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
+    SettingsViewController *settingsViewController = [[SettingsViewController alloc] initWithSettingsController:settingsController settingsModel:settingsModel];
+    settingsViewController.title = NSLocalizedString(@"ProfileTitle", @"");
+  	self.settingsViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
+  }
 
   UIImage *profileImage;
   profileImage = [UIImage imageNamed:@"user"];

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -192,7 +192,7 @@ static BOOL kSignUpEnabled = YES;
   profileTableViewController.locationModel = locationModel;
   self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:profileTableViewController];
 #pragma mark - SettingsViewController
-  if (/* DISABLES CODE */ (NO)) {
+  if (/* DISABLES CODE */ (YES)) {
   	SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
     SettingsController *settingsController = [[SettingsController alloc] initWithModel:settingsModel userController:userController userModel:userModel];
 
@@ -210,7 +210,7 @@ static BOOL kSignUpEnabled = YES;
 
   if (kSignUpEnabled) {
     self.viewControllers = @[self.indexViewControllerWithNavigation, self.mapControllerWithNavigation,
-                             self.bookmarksControllerWithNavigation, self.profileControllerWithNavigation];
+                             self.bookmarksControllerWithNavigation, self.settingsViewControllerWithNavigation];
   } else {
     self.viewControllers = @[self.indexViewControllerWithNavigation, self.mapControllerWithNavigation,
                              self.bookmarksControllerWithNavigation];

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -39,6 +39,9 @@
 #import "AuthService.h"
 #import "AccessibilityIdentifiers.h"
 #import "AccessibilityUtils.h"
+#import "SettingsViewController.h"
+#import "SettingsModel.h"
+#import "SettingsController.h"
 
 #if PROD
 static BOOL kSignUpEnabled = YES;
@@ -174,19 +177,14 @@ static BOOL kSignUpEnabled = YES;
     self.bookmarksControllerWithNavigation.navigationBar.titleTextAttributes =
     [TypographyLegacy get].navigationSemiboldAttributes;
 
-#pragma mark - ProfileRootViewController
-  ProfileTableViewController *profileTableViewController = [[ProfileTableViewController alloc] initWithController:userController model:userModel];
-  profileTableViewController.title = NSLocalizedString(@"ProfileTitle", @"");
-  profileTableViewController.bookmarksGroupModel = bookmarksGroupsModel;
-  profileTableViewController.indexModel = self.indexModel;
-  profileTableViewController.apiService = self.apiService;
-  profileTableViewController.coreDataService = self.coreDataService;
-  profileTableViewController.mapService = self.mapService;
-  profileTableViewController.mapModel = mapModel;
-  profileTableViewController.searchModel = searchModel;
-  profileTableViewController.detailsModel = detailsModel;
-  profileTableViewController.locationModel = locationModel;
-  self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:profileTableViewController];
+#pragma mark - SettingsViewController
+  SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
+  SettingsController *settingsController = [[SettingsController alloc] initWithModel:settingsModel userController:userController userModel:userModel];
+
+  SettingsViewController *settingsViewController = [[SettingsViewController alloc] initWithSettingsController:settingsController settingsModel:settingsModel];
+  settingsViewController.title = NSLocalizedString(@"ProfileTitle", @"");
+  
+  self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
 
   UIImage *profileImage;
   profileImage = [UIImage imageNamed:@"user"];

--- a/ios/screens/MainViewController/MainViewController.m
+++ b/ios/screens/MainViewController/MainViewController.m
@@ -191,6 +191,13 @@ static BOOL kSignUpEnabled = YES;
   profileTableViewController.detailsModel = detailsModel;
   profileTableViewController.locationModel = locationModel;
   self.profileControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:profileTableViewController];
+  
+  UIImage *profileImage;
+  profileImage = [UIImage imageNamed:@"user"];
+  self.profileTabBarItem = createTabBarItem(NSLocalizedString(@"TabBarProfile", @""), 0, profileImage,
+                                            AccessibilityIdentifiersTabBarProfile);
+
+  self.profileControllerWithNavigation.tabBarItem = self.profileTabBarItem;
 #pragma mark - SettingsViewController
   if (/* DISABLES CODE */ (YES)) {
   	SettingsModel *settingsModel = [[SettingsModel alloc] initWithUserController:userController userModel:userModel];
@@ -199,14 +206,8 @@ static BOOL kSignUpEnabled = YES;
     SettingsViewController *settingsViewController = [[SettingsViewController alloc] initWithSettingsController:settingsController settingsModel:settingsModel];
     settingsViewController.title = NSLocalizedString(@"ProfileTitle", @"");
   	self.settingsViewControllerWithNavigation = [[UINavigationController alloc] initWithRootViewController:settingsViewController];
+    self.settingsViewControllerWithNavigation.tabBarItem = self.profileTabBarItem;
   }
-
-  UIImage *profileImage;
-  profileImage = [UIImage imageNamed:@"user"];
-  self.profileTabBarItem = createTabBarItem(NSLocalizedString(@"TabBarProfile", @""), 0, profileImage,
-                                            AccessibilityIdentifiersTabBarProfile);
-
-  self.profileControllerWithNavigation.tabBarItem = self.profileTabBarItem;
 
   if (kSignUpEnabled) {
     self.viewControllers = @[self.indexViewControllerWithNavigation, self.mapControllerWithNavigation,

--- a/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.h
+++ b/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.h
@@ -1,0 +1,16 @@
+//
+//  AuthLoggedInTableViewCell.h
+//  greenTravel
+//
+//  Created by Alex K on 25.01.23.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AuthLoggedInTableViewCell : UITableViewCell
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.m
+++ b/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.m
@@ -9,15 +9,4 @@
 
 @implementation AuthLoggedInTableViewCell
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end

--- a/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.m
+++ b/ios/screens/SettingsViewController/AuthLoggedInTableViewCell/AuthLoggedInTableViewCell.m
@@ -1,0 +1,23 @@
+//
+//  AuthLoggedInTableViewCell.m
+//  greenTravel
+//
+//  Created by Alex K on 25.01.23.
+//
+
+#import "AuthLoggedInTableViewCell.h"
+
+@implementation AuthLoggedInTableViewCell
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.h
+++ b/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.h
@@ -1,0 +1,16 @@
+//
+//  AuthLoggedOutTableViewCell.h
+//  greenTravel
+//
+//  Created by Alex K on 25.01.23.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AuthLoggedOutTableViewCell : UITableViewCell
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.m
+++ b/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.m
@@ -1,0 +1,23 @@
+//
+//  AuthLoggedOutTableViewCell.m
+//  greenTravel
+//
+//  Created by Alex K on 25.01.23.
+//
+
+#import "AuthLoggedOutTableViewCell.h"
+
+@implementation AuthLoggedOutTableViewCell
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.m
+++ b/ios/screens/SettingsViewController/AuthLoggedOutTableViewCell/AuthLoggedOutTableViewCell.m
@@ -9,15 +9,4 @@
 
 @implementation AuthLoggedOutTableViewCell
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.h
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.h
@@ -11,6 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SettingsAuthTableViewCell : UITableViewCell
 
+- (void)updateWithSubTitle:(NSString*)subText
+        fetchingInProgress:(BOOL)fetchingInProgress
+                  signedIn:(BOOL)signedIn;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.h
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.h
@@ -1,0 +1,16 @@
+//
+//  SettingsAuthTableViewCell.h
+//  greenTravel
+//
+//  Created by Alex K on 31.01.23.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsAuthTableViewCell : UITableViewCell
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -119,7 +119,7 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
 
 - (void)setUpAvatar:(NSString *)subText signedIn:(BOOL)signedIn {
   if (!signedIn) {
-    self.iconImageVie3w.image = [UIImage imageNamed:@"accountPhoto"];
+    self.iconImageView.image = [UIImage imageNamed:@"accountPhoto"];
     return;
   }
   

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -9,7 +9,7 @@
 #import "CacheService.h"
 #import "Typography.h"
 #import "Colors.h"
-#import "UIImage+extensions.h""
+#import "UIImage+extensions.h"
 
 @interface SettingsAuthTableViewCell()
 

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -31,16 +31,6 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
 
 @implementation SettingsAuthTableViewCell
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-    // Initialization code
-}
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-}
-
-
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
@@ -49,9 +39,7 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
     return self;
 }
 
-- (void)setUp {
-  
-}
+- (void)setUp {}
 
 - (void)prepareTableViewCell {
   self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -79,13 +79,7 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
   [self.contentView addSubview:self.iconImageView];
   
 #pragma mark - Avatar
-  UIImage *image = [[CacheService get].cache objectForKey:kAvatarCacheKey];
-  if (image == nil) {
-    image = [[UIImage alloc] getAccountImageWithChar:[subText substringToIndex:1]];
-    [[CacheService get].cache setObject:image forKey:kAvatarCacheKey];
-  }
-  
-  self.iconImageView.image = image;
+  [self setUpAvatar:subText signedIn:YES];
   
   [NSLayoutConstraint activateConstraints:@[
     [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:kIconLeadingAnchor],
@@ -152,6 +146,21 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
     NSAttributedString *subTextLabelAttributedString = [[Typography get] makeProfileTableViewCellSubTextLabelForAuthCell:NSLocalizedString(@"SettingsViewControllerAuthCellSubTitleAuthorizedNot", @"")];
     [self.subLabel setAttributedText:subTextLabelAttributedString];
   }
+}
+
+- (void)setUpAvatar:(NSString *)subText signedIn:(BOOL)signedIn {
+  if (!signedIn) {
+    self.iconImageView.image = [UIImage imageNamed:@"accountPhoto"];
+    return;
+  }
+  
+  UIImage *image = [[CacheService get].cache objectForKey:kAvatarCacheKey];
+  if (image == nil) {
+    image = [[UIImage alloc] getAccountImageWithChar:[subText substringToIndex:1]];
+    [[CacheService get].cache setObject:image forKey:kAvatarCacheKey];
+  }
+  
+  self.iconImageView.image = image;
 }
 
 - (void)prepareForReuse {

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -39,36 +39,12 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
     return self;
 }
 
-- (void)setUp {}
-
-- (void)prepareTableViewCell {
-  self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-  
+- (void)setUp {
   self.iconImageView = [[UIImageView alloc] init];
   self.iconImageView.translatesAutoresizingMaskIntoConstraints = NO;
   
   [self.contentView addSubview:self.iconImageView];
-  
-  [NSLayoutConstraint activateConstraints:@[
-  [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:kIconLeadingAnchor],
-  [self.iconImageView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-  [self.iconImageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:kIconTopAnchor],
-  [self.iconImageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:kIconBottomAnchor],
-  [self.iconImageView.widthAnchor constraintEqualToAnchor:self.iconImageView.heightAnchor]
-  ]];
-}
-
-- (void)updateWithSubTitle:(NSString*)subText
-        fetchingInProgress:(BOOL)fetchingInProgress
-                  signedIn:(BOOL)signedIn {
-  self.iconImageView = [[UIImageView alloc] init];
-  self.iconImageView.translatesAutoresizingMaskIntoConstraints = NO;
-  
-  [self.contentView addSubview:self.iconImageView];
-  
 #pragma mark - Avatar
-  [self setUpAvatar:subText signedIn:YES];
-  
   [NSLayoutConstraint activateConstraints:@[
     [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:kIconLeadingAnchor],
     [self.iconImageView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
@@ -106,7 +82,11 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
     [labelStack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:kMainLabelTrailingAnchor],
     [labelStack.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
   ]];
-  
+}
+
+- (void)updateWithSubTitle:(NSString*)subText
+        fetchingInProgress:(BOOL)fetchingInProgress
+                  signedIn:(BOOL)signedIn {
   if (fetchingInProgress) {
     UIActivityIndicatorView *activityIndicator = [[UIActivityIndicatorView alloc] init];
     self.accessoryView = activityIndicator;
@@ -134,6 +114,7 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
     NSAttributedString *subTextLabelAttributedString = [[Typography get] makeProfileTableViewCellSubTextLabelForAuthCell:NSLocalizedString(@"SettingsViewControllerAuthCellSubTitleAuthorizedNot", @"")];
     [self.subLabel setAttributedText:subTextLabelAttributedString];
   }
+  [self setUpAvatar:subText signedIn:YES];
 }
 
 - (void)setUpAvatar:(NSString *)subText signedIn:(BOOL)signedIn {

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -119,7 +119,7 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
 
 - (void)setUpAvatar:(NSString *)subText signedIn:(BOOL)signedIn {
   if (!signedIn) {
-    self.iconImageView.image = [UIImage imageNamed:@"accountPhoto"];
+    self.iconImageVie3w.image = [UIImage imageNamed:@"accountPhoto"];
     return;
   }
   

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -114,9 +114,9 @@ static NSString * const kAvatarCacheKey = @"avatarImage";
   [self.contentView addSubview:labelStack];
   
   [NSLayoutConstraint activateConstraints:@[
-  [labelStack.leadingAnchor constraintEqualToAnchor:self.iconImageView.trailingAnchor constant:kMainLabelLeadingAnchor],
-  [labelStack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:kMainLabelTrailingAnchor],
-  [labelStack.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
+    [labelStack.leadingAnchor constraintEqualToAnchor:self.iconImageView.trailingAnchor constant:kMainLabelLeadingAnchor],
+    [labelStack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:kMainLabelTrailingAnchor],
+    [labelStack.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
   ]];
   
   if (fetchingInProgress) {

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -1,0 +1,25 @@
+//
+//  SettingsAuthTableViewCell.m
+//  greenTravel
+//
+//  Created by Alex K on 31.01.23.
+//
+
+#import "SettingsAuthTableViewCell.h"
+
+@implementation SettingsAuthTableViewCell()
+
+@implementation SettingsAuthTableViewCell
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+}
+
+
+
+@end

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCell.m
@@ -9,6 +9,12 @@
 
 @implementation SettingsAuthTableViewCell()
 
+@property (strong, nonatomic)UIImageView *iconImageView;
+@property (strong, nonatomic)UILabel *mainLabel;
+@property (strong, nonatomic)UILabel *subLabel;
+
+@end
+
 @implementation SettingsAuthTableViewCell
 
 - (void)awakeFromNib {
@@ -21,5 +27,137 @@
 }
 
 
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        [self setUp];
+    }
+    return self;
+}
+
+- (void)setUp {
+  
+}
+
+- (void)prepareTableViewCell {
+  self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+  
+  self.iconImageView = [[UIImageView alloc] init];
+  self.iconImageView.translatesAutoresizingMaskIntoConstraints = NO;
+  
+  [self.contentView addSubview:self.iconImageView];
+  
+  [NSLayoutConstraint activateConstraints:@[
+  [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:kIconLeadingAnchor],
+  [self.iconImageView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+  [self.iconImageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:kIconTopAnchor],
+  [self.iconImageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:kIconBottomAnchor],
+  [self.iconImageView.widthAnchor constraintEqualToAnchor:self.iconImageView.heightAnchor]
+  ]];
+}
+
+- (void)prepareSettingsCellWithImage:(UIImage*)image mainTextLabelText:(NSString*)mainText subTextLabelText:(NSString*)subText {
+  [self prepareTableViewCell];
+  
+  self.iconImageView.image = image;
+  
+  self.mainLabel = [[UILabel alloc] init];
+  NSAttributedString *mainTextLabelAttributedString = [[Typography get] makeProfileTableViewCellMainTextLabelForSettingsCell:mainText];
+  self.mainLabel.attributedText = mainTextLabelAttributedString;
+  
+  self.mainLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.contentView addSubview:self.mainLabel];
+  
+  [NSLayoutConstraint activateConstraints:@[
+  [self.mainLabel.leadingAnchor constraintEqualToAnchor:self.iconImageView.trailingAnchor constant:kMainLabelLeadingAnchor],
+  [self.mainLabel.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
+  ]];
+  
+  self.subLabel = [[UILabel alloc] init];
+  NSAttributedString *subTextLabelAttributedString = [[Typography get] makeProfileTableViewCellSubTextLabelForSettingsCell:subText];
+  self.subLabel.attributedText = subTextLabelAttributedString;
+  
+  self.subLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.contentView addSubview:self.subLabel];
+  
+  [NSLayoutConstraint activateConstraints:@[
+  [self.subLabel.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:kSubLabelTrailingAnchor],
+  [self.subLabel.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+  [self.subLabel.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.mainLabel.trailingAnchor constant:kSubLabelLeadingAnchor]
+  ]];
+}
+
+- (void)prepareAuthCellWithImage:(UIImage*)image
+               mainTextLabelText:(NSString*)mainText
+                subTextLabelText:(NSString*)subText
+              fetchingInProgress:(BOOL)fetchingInProgress
+              signedIn:(BOOL)signedIn {
+  if (fetchingInProgress) {
+    UIActivityIndicatorView *activityIndicator = [[UIActivityIndicatorView alloc] init];
+    self.accessoryView = activityIndicator;
+    [activityIndicator sizeToFit];
+    [activityIndicator startAnimating];
+    self.accessoryType = UITableViewCellAccessoryNone;
+  }
+  if (!fetchingInProgress && signedIn) {
+    self.accessoryView = nil;
+    self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+  }
+  if (!fetchingInProgress && !signedIn) {
+    self.accessoryView = nil;
+    self.accessoryType = UITableViewCellAccessoryNone;
+  }
+  
+  self.iconImageView = [[UIImageView alloc] init];
+  self.iconImageView.translatesAutoresizingMaskIntoConstraints = NO;
+  
+  [self.contentView addSubview:self.iconImageView];
+  
+  self.iconImageView.image = image;
+  
+  [NSLayoutConstraint activateConstraints:@[
+    [self.iconImageView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:kIconLeadingAnchor],
+    [self.iconImageView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+    [self.iconImageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:kIconTopAnchorAtAuthCell],
+    [self.iconImageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:kIconBottomAnchorAtAuthCell],
+    [self.iconImageView.widthAnchor constraintEqualToAnchor:self.iconImageView.heightAnchor]
+  ]];
+  
+  self.mainLabel = [[UILabel alloc] init];
+  self.mainLabel.textAlignment = NSTextAlignmentLeft;
+  NSAttributedString *mainTextLabelAttributedString = [[Typography get] makeProfileTableViewCellMainTextLabelForAuthCell:mainText];
+  self.mainLabel.attributedText = mainTextLabelAttributedString;
+  
+  self.mainLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  
+  self.subLabel = [[UILabel alloc] init];
+  self.subLabel.textAlignment = NSTextAlignmentLeft;
+  self.subLabel.numberOfLines = 0;
+  NSAttributedString *subTextLabelAttributedString = [[Typography get] makeProfileTableViewCellSubTextLabelForAuthCell:subText];
+  self.subLabel.attributedText = subTextLabelAttributedString;
+  [self.subLabel sizeToFit];
+  
+  self.subLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  
+  UIStackView *labelStack = [[UIStackView alloc] init];
+  [labelStack addArrangedSubview:self.mainLabel];
+  [labelStack addArrangedSubview:self.subLabel];
+  labelStack.axis = UILayoutConstraintAxisVertical;
+  labelStack.distribution = UIStackViewDistributionFillProportionally;
+  labelStack.spacing = 4;
+  
+  labelStack.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.contentView addSubview:labelStack];
+  
+  [NSLayoutConstraint activateConstraints:@[
+  [labelStack.leadingAnchor constraintEqualToAnchor:self.iconImageView.trailingAnchor constant:kMainLabelLeadingAnchor],
+  [labelStack.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:kMainLabelTrailingAnchor],
+  [labelStack.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor]
+  ]];
+}
+
+- (void)prepareForReuse {
+  
+}
 
 @end

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCellUtils.h
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCellUtils.h
@@ -1,0 +1,16 @@
+//
+//  SettingsAuthTableViewCellUtils.h
+//  greenTravel
+//
+//  Created by Alex K on 4.02.23.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsAuthTableViewCellUtils : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCellUtils.m
+++ b/ios/screens/SettingsViewController/SettingsAuthTableViewCell/SettingsAuthTableViewCellUtils.m
@@ -1,0 +1,12 @@
+//
+//  SettingsAuthTableViewCellUtils.m
+//  greenTravel
+//
+//  Created by Alex K on 4.02.23.
+//
+
+#import "SettingsAuthTableViewCellUtils.h"
+
+@implementation SettingsAuthTableViewCellUtils
+
+@end

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.h
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.h
@@ -1,0 +1,20 @@
+//
+//  SettingsBaseTableViewCell.h
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SettingsBaseTableViewCellConfig;
+
+@interface SettingsBaseTableViewCell : UITableViewCell
+
+- (void)update:(SettingsBaseTableViewCellConfig *)config;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -22,6 +22,7 @@
 @property (strong, nonatomic) SettingsBaseTableViewCellConfig *config;
 @property (strong, nonatomic) NSLayoutConstraint *titleLeading;
 @property (strong, nonatomic) NSLayoutConstraint *titleTrailing;
+@property (strong, nonatomic) NSLayoutConstraint *subTitleTrailing;
 
 @end
 
@@ -68,7 +69,7 @@ static const CGFloat kSpacing = 16.0;
   self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
   [NSLayoutConstraint activateConstraints:@[
     [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-    [self.subTitle.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor]
+    self.subTitleTrailing = [self.subTitle.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-kSpacing]
   ]];
 #pragma mark - Title
   self.title = [[UILabel alloc] init];
@@ -83,7 +84,7 @@ static const CGFloat kSpacing = 16.0;
     [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
     self.titleLeading = [self.title.leadingAnchor constraintEqualToAnchor:self.iconView.trailingAnchor constant:kSpacing],
     self.titleTrailing = [self.title.trailingAnchor
-                             constraintGreaterThanOrEqualToAnchor:self.subTitle.leadingAnchor constant:-kSpacing],
+                             constraintLessThanOrEqualToAnchor:self.subTitle.leadingAnchor constant:-kSpacing],
   ]];
 #pragma mark - Accessory view
   self.accessoryType = UITableViewCellAccessoryNone;
@@ -104,15 +105,17 @@ static const CGFloat kSpacing = 16.0;
   BOOL subTitleIsPresent = self.config.subTitle != nil;
   if (subTitleIsPresent) {
     [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
-    return;
+    [self.subTitle setHidden:NO];
+  } else {
+    [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:@""]];
+    [self.subTitle setHidden:YES];
   }
-  [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:@""]];
 #pragma mark - Title
   [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
   if (iconIsPresent) {
     self.titleLeading.constant = kSpacing;
   } else {
-    self.titleLeading.constant = -kSpacing - kIconSize;
+    self.titleLeading.constant = -2 * kSpacing;
   }
   if (subTitleIsPresent) {
     self.titleTrailing.constant = -kSpacing;

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -14,11 +14,11 @@
 
 @interface SettingsBaseTableViewCell ()
 
-@property (strong, nonatomic) UIStackView *titleStack;
 @property (strong, nonatomic) UILabel *title;
 @property (strong, nonatomic) UILabel *subTitle;
 @property (strong, nonatomic) UIImageView *iconView;
 @property (strong, nonatomic) UIView *separatorView;
+@property (strong, nonatomic) UIStackView *labelStack;
 @property (strong, nonatomic) SettingsBaseTableViewCellConfig *config;
 
 @end
@@ -35,7 +35,7 @@
   self.backgroundColor = [Colors get].background;
   [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
   if (self.config.subTitle != nil) {
-    [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+    [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
   }
 }
 
@@ -62,10 +62,10 @@
     self.iconView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:self.iconView];
     [NSLayoutConstraint activateConstraints:@[
-        [self.iconView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0],
-        [self.iconView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-        [self.iconView.widthAnchor constraintEqualToConstant:30.0],
-        [self.iconView.heightAnchor constraintEqualToConstant:30.0],
+      [self.iconView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0],
+      [self.iconView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+      [self.iconView.widthAnchor constraintEqualToConstant:30.0],
+      [self.iconView.heightAnchor constraintEqualToConstant:30.0],
     ]];
     prevView = self.iconView;
   }
@@ -75,7 +75,8 @@
     [self.contentView addSubview:self.title];
     self.title.numberOfLines = 1;
     self.title.adjustsFontSizeToFitWidth = NO;
-    self.title.lineBreakMode = NSLineBreakByTruncatingTail;
+    [self.title setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [self.title setLineBreakMode:NSLineBreakByTruncatingTail];
     self.title.translatesAutoresizingMaskIntoConstraints = NO;
     NSLayoutConstraint *leading;
     if (prevView != nil) {
@@ -84,46 +85,43 @@
       leading = [self.title.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0];
     }
     [NSLayoutConstraint activateConstraints:@[
-        [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-        leading,
+      [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+      leading,
     ]];
     prevView = self.title;
 #pragma mark - Sub title
     [self.subTitle removeFromSuperview];
-    if (self.config.subTitle != nil && ![self.config.subTitle isEqualToString:@""]) {
-      self.subTitle = [[UILabel alloc] init];
-      [self.contentView addSubview:self.title];
-      self.subTitle.numberOfLines = 1;
-      self.subTitle.adjustsFontSizeToFitWidth = NO;
-      self.subTitle.lineBreakMode = NSLineBreakByTruncatingTail;
-      self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
-      [NSLayoutConstraint activateConstraints:@[
-          [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-          [self.subTitle.leadingAnchor
-                     constraintGreaterThanOrEqualToAnchor:prevView.trailingAnchor constant:16.0],
-      ]];
-      
-      prevView = self.subTitle;
-    }
+    
+    self.subTitle = [[UILabel alloc] init];
+    [self.contentView addSubview:self.subTitle];
+    self.subTitle.numberOfLines = 1;
+    self.subTitle.adjustsFontSizeToFitWidth = NO;
+    [self.subTitle setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+    self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
+    [NSLayoutConstraint activateConstraints:@[
+      [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+      [self.subTitle.leadingAnchor
+       constraintGreaterThanOrEqualToAnchor:prevView.trailingAnchor constant:16.0],
+    ]];
+    prevView = self.subTitle;
 #pragma mark - Accessory view
-    NSLayoutConstraint *trailing;
     if (self.config.chevron) {
       self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-      trailing = [prevView.trailingAnchor constraintEqualToAnchor:self.accessoryView.leadingAnchor constant:-16.0];
     } else {
-      trailing = [prevView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16.0],
       self.accessoryType = UITableViewCellAccessoryNone;
     }
-    [NSLayoutConstraint activateConstraints:@[trailing]];
+    [NSLayoutConstraint activateConstraints:@[[prevView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16.0]]];
 }
 
 - (void)update:(SettingsBaseTableViewCellConfig *)entry {
-  [self setUp];
   self.config = entry;
+  [self setUp];
   [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
   if (self.config.subTitle != nil) {
-    [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+    [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+    return;
   }
+  [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:@""]];
 }
 
 - (void)prepareForReuse {

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -25,11 +25,6 @@
 
 @implementation SettingsBaseTableViewCell
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-    // Initialization code
-}
-
 - (void)layoutSubviews {
   [super layoutSubviews];
   self.backgroundColor = [Colors get].background;

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -20,6 +20,9 @@
 @property (strong, nonatomic) UIView *separatorView;
 @property (strong, nonatomic) UIStackView *labelStack;
 @property (strong, nonatomic) SettingsBaseTableViewCellConfig *config;
+@property (strong, nonatomic) NSArray<NSLayoutConstraint *> *iconConstraints;
+@property (strong, nonatomic) NSLayoutConstraint *leadingWithIcon;
+@property (strong, nonatomic) NSLayoutConstraint *leadingNoIcon;
 
 @end
 
@@ -49,74 +52,85 @@
 }
 
 - (void)setUp {
-  UIView *prevView = nil;
 #pragma mark - Icon
-  [self.iconView removeFromSuperview];
-  if (self.config.iconName != nil && ![self.config.iconName isEqualToString:@""]) {
-    self.iconView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:self.config.iconName]];
-    self.iconView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.contentView addSubview:self.iconView];
-    [NSLayoutConstraint activateConstraints:@[
-      [self.iconView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0],
-      [self.iconView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-      [self.iconView.widthAnchor constraintEqualToConstant:30.0],
-      [self.iconView.heightAnchor constraintEqualToConstant:30.0],
-    ]];
-    prevView = self.iconView;
-  }
+  self.iconView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:self.config.iconName]];
+  self.iconView.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.contentView addSubview:self.iconView];
+  
+  self.iconConstraints = @[
+    [self.iconView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0],
+    [self.iconView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+    [self.iconView.widthAnchor constraintEqualToConstant:30.0],
+    [self.iconView.heightAnchor constraintEqualToConstant:30.0],
+  ];
 #pragma mark - Title
-    [self.title removeFromSuperview];
-    self.title = [[UILabel alloc] init];
-    [self.contentView addSubview:self.title];
-    self.title.numberOfLines = 1;
-    self.title.adjustsFontSizeToFitWidth = NO;
-    [self.title setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
-    [self.title setLineBreakMode:NSLineBreakByTruncatingTail];
-    self.title.translatesAutoresizingMaskIntoConstraints = NO;
-    NSLayoutConstraint *leading;
-    if (prevView != nil) {
-      leading = [self.title.leadingAnchor constraintEqualToAnchor:prevView.trailingAnchor constant:16.0];
-    } else {
-      leading = [self.title.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0];
-    }
-    [NSLayoutConstraint activateConstraints:@[
-      [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-      leading,
-    ]];
-    prevView = self.title;
+  self.title = [[UILabel alloc] init];
+  [self.contentView addSubview:self.title];
+  self.title.numberOfLines = 1;
+  self.title.adjustsFontSizeToFitWidth = NO;
+  [self.title setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+  [self.title setLineBreakMode:NSLineBreakByTruncatingTail];
+  self.title.translatesAutoresizingMaskIntoConstraints = NO;
 #pragma mark - Sub title
-    [self.subTitle removeFromSuperview];
-    
-    self.subTitle = [[UILabel alloc] init];
-    [self.contentView addSubview:self.subTitle];
-    self.subTitle.numberOfLines = 1;
-    self.subTitle.adjustsFontSizeToFitWidth = NO;
-    [self.subTitle setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
-    self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:@[
-      [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
-      [self.subTitle.leadingAnchor
-       constraintGreaterThanOrEqualToAnchor:prevView.trailingAnchor constant:16.0],
-    ]];
-    prevView = self.subTitle;
+  self.subTitle = [[UILabel alloc] init];
+  [self.contentView addSubview:self.subTitle];
+  self.subTitle.numberOfLines = 1;
+  self.subTitle.adjustsFontSizeToFitWidth = NO;
+  [self.subTitle setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+  self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
 #pragma mark - Accessory view
-    if (self.config.chevron) {
-      self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    } else {
-      self.accessoryType = UITableViewCellAccessoryNone;
-    }
-    [NSLayoutConstraint activateConstraints:@[[prevView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16.0]]];
+  self.accessoryType = UITableViewCellAccessoryNone;
 }
 
 - (void)update:(SettingsBaseTableViewCellConfig *)entry {
   self.config = entry;
-  [self setUp];
-  [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
+  
   if (self.config.subTitle != nil) {
     [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
     return;
   }
   [self.subTitle setAttributedText:[[Typography get] settingsCellSubTitle:@""]];
+  
+  UIView *prevView = nil;
+#pragma mark - Icon
+  if (self.config.iconName != nil && ![self.config.iconName isEqualToString:@""]) {
+    [self.iconView setImage:[UIImage imageNamed:self.config.iconName]];
+    [NSLayoutConstraint activateConstraints:self.iconConstraints];
+    [self.iconView setHidden:NO];
+    prevView = self.iconView;
+  } else {
+    [NSLayoutConstraint deactivateConstraints:self.iconConstraints];
+    [self.iconView setHidden:YES];
+  }
+#pragma mark - Title
+  [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
+  [NSLayoutConstraint deactivateConstraints:@[self.leadingWithIcon, self.leadingNoIcon]];
+  NSLayoutConstraint *leading;
+  if (prevView != nil) {
+    leading = self.leadingWithIcon = [self.title.leadingAnchor constraintEqualToAnchor:prevView.trailingAnchor constant:16.0];
+  } else {
+    leading = self.leadingNoIcon = [self.title.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0];
+  }
+  [NSLayoutConstraint activateConstraints:@[
+    [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+    leading,
+  ]];
+  prevView = self.title;
+#pragma mark - Sub title
+  [NSLayoutConstraint activateConstraints:@[
+    [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+    [self.subTitle.leadingAnchor
+     constraintGreaterThanOrEqualToAnchor:prevView.trailingAnchor constant:16.0],
+  ]];
+  prevView = self.subTitle;
+#pragma mark - Accessory view
+  if (self.config.chevron) {
+    self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+  } else {
+    self.accessoryType = UITableViewCellAccessoryNone;
+  }
+  [NSLayoutConstraint activateConstraints:@[[prevView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16.0]]];
+  
 }
 
 - (void)prepareForReuse {

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -34,7 +34,9 @@
   [super layoutSubviews];
   self.backgroundColor = [Colors get].background;
   [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
-  [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+  if (self.config.subTitle != nil) {
+    [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+  }
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
@@ -119,7 +121,9 @@
   [self setUp];
   self.config = entry;
   [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
-  [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+  if (self.config.subTitle != nil) {
+    [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+  }
 }
 
 - (void)prepareForReuse {

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCell.m
@@ -1,0 +1,134 @@
+//
+//  SettingsBaseTableViewCell.m
+//  greenTravel
+//
+//  Created by Alex K on 21.01.23.
+//
+
+#import "SettingsBaseTableViewCell.h"
+#import "ColorsLegacy.h"
+#import "Colors.h"
+#import "TextUtils.h"
+#import "SettingsBaseTableViewCellConfig.h"
+#import "Typography.h"
+
+@interface SettingsBaseTableViewCell ()
+
+@property (strong, nonatomic) UIStackView *titleStack;
+@property (strong, nonatomic) UILabel *title;
+@property (strong, nonatomic) UILabel *subTitle;
+@property (strong, nonatomic) UIImageView *iconView;
+@property (strong, nonatomic) UIView *separatorView;
+@property (strong, nonatomic) SettingsBaseTableViewCellConfig *config;
+
+@end
+
+@implementation SettingsBaseTableViewCell
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  self.backgroundColor = [Colors get].background;
+  [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
+  [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        [self setUp];
+    }
+    return self;
+}
+
+- (void)setUp {
+  UIView *prevView = nil;
+#pragma mark - Icon
+  [self.iconView removeFromSuperview];
+  if (self.config.iconName != nil && ![self.config.iconName isEqualToString:@""]) {
+    self.iconView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:self.config.iconName]];
+    self.iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:self.iconView];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.iconView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0],
+        [self.iconView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+        [self.iconView.widthAnchor constraintEqualToConstant:30.0],
+        [self.iconView.heightAnchor constraintEqualToConstant:30.0],
+    ]];
+    prevView = self.iconView;
+  }
+#pragma mark - Title
+    [self.title removeFromSuperview];
+    self.title = [[UILabel alloc] init];
+    [self.contentView addSubview:self.title];
+    self.title.numberOfLines = 1;
+    self.title.adjustsFontSizeToFitWidth = NO;
+    self.title.lineBreakMode = NSLineBreakByTruncatingTail;
+    self.title.translatesAutoresizingMaskIntoConstraints = NO;
+    NSLayoutConstraint *leading;
+    if (prevView != nil) {
+      leading = [self.title.leadingAnchor constraintEqualToAnchor:prevView.trailingAnchor constant:16.0];
+    } else {
+      leading = [self.title.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16.0];
+    }
+    [NSLayoutConstraint activateConstraints:@[
+        [self.title.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+        leading,
+    ]];
+    prevView = self.title;
+#pragma mark - Sub title
+    [self.subTitle removeFromSuperview];
+    if (self.config.subTitle != nil && ![self.config.subTitle isEqualToString:@""]) {
+      self.subTitle = [[UILabel alloc] init];
+      [self.contentView addSubview:self.title];
+      self.subTitle.numberOfLines = 1;
+      self.subTitle.adjustsFontSizeToFitWidth = NO;
+      self.subTitle.lineBreakMode = NSLineBreakByTruncatingTail;
+      self.subTitle.translatesAutoresizingMaskIntoConstraints = NO;
+      [NSLayoutConstraint activateConstraints:@[
+          [self.subTitle.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+          [self.subTitle.leadingAnchor
+                     constraintGreaterThanOrEqualToAnchor:prevView.trailingAnchor constant:16.0],
+      ]];
+      
+      prevView = self.subTitle;
+    }
+#pragma mark - Accessory view
+    NSLayoutConstraint *trailing;
+    if (self.config.chevron) {
+      self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+      trailing = [prevView.trailingAnchor constraintEqualToAnchor:self.accessoryView.leadingAnchor constant:-16.0];
+    } else {
+      trailing = [prevView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16.0],
+      self.accessoryType = UITableViewCellAccessoryNone;
+    }
+    [NSLayoutConstraint activateConstraints:@[trailing]];
+}
+
+- (void)update:(SettingsBaseTableViewCellConfig *)entry {
+  [self setUp];
+  self.config = entry;
+  [self.title setAttributedText:[[Typography get] settingsCellTitle:self.config.title]];
+  [self.title setAttributedText:[[Typography get] settingsCellSubTitle:self.config.subTitle]];
+}
+
+- (void)prepareForReuse {
+  [super prepareForReuse];
+  [self.iconView removeFromSuperview];
+  self.accessoryType = UITableViewCellAccessoryNone;
+  [self.subTitle removeFromSuperview];
+  [self.title setAttributedText:[[Typography get] settingsCellTitle:@""]];
+  [self.subTitle setAttributedText:[[Typography get] settingsCellTitle:@""]];
+}
+
+@end

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCellConfig.h
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCellConfig.h
@@ -1,0 +1,27 @@
+//
+//  SettingsBaseTableViewCellConfig.h
+//  greenTravel
+//
+//  Created by Alex K on 22.01.23.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SettingsBaseTableViewCellConfig : NSObject
+
+@property (assign, nonatomic) BOOL chevron;
+@property (strong, nonatomic) NSString *iconName;
+@property (strong, nonatomic) NSString *title;
+@property (strong, nonatomic) NSString *subTitle;
+
+- (instancetype)initWithTitle:(NSString *)title
+                     subTitle:(NSString *)subTitle
+                     iconName:(NSString *)iconName
+                      chevron:(BOOL)chevron;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCellConfig.m
+++ b/ios/screens/SettingsViewController/SettingsBaseTableViewCell/SettingsBaseTableViewCellConfig.m
@@ -1,0 +1,25 @@
+//
+//  SettingsBaseTableViewCellConfig.m
+//  greenTravel
+//
+//  Created by Alex K on 22.01.23.
+//
+
+#import "SettingsBaseTableViewCellConfig.h"
+
+@implementation SettingsBaseTableViewCellConfig
+
+- (instancetype)initWithTitle:(NSString *)title
+                     subTitle:(NSString *)subTitle
+                     iconName:(NSString *)iconName
+                      chevron:(BOOL)chevron {
+  if (self = [super init]) {
+    _title = title;
+    _subTitle = subTitle;
+    _chevron = chevron;
+    _iconName = iconName;
+  }
+  return self;
+}
+
+@end

--- a/ios/screens/SettingsViewController/SettingsToggleTableViewCell/SettingsToggleTableViewCell.h
+++ b/ios/screens/SettingsViewController/SettingsToggleTableViewCell/SettingsToggleTableViewCell.h
@@ -9,7 +9,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SettingsEntryToggle;
+
 @interface SettingsToggleTableViewCell : UITableViewCell
+
+- (void)update:(NSString *)title enabled:(BOOL)enabled onToggle:(void(^_Nonnull)(BOOL))onToggle;
 
 @end
 

--- a/ios/screens/SettingsViewController/SettingsViewController.h
+++ b/ios/screens/SettingsViewController/SettingsViewController.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "SettingsModelObserver.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SettingsModel;
 @class SettingsScreen;
 
-@interface SettingsViewController : UITableViewController
+@interface SettingsViewController : UITableViewController<SettingsModelObserver>
 
 - (instancetype)initWithSettingsController:(SettingsController *)settingsController
                              settingsModel:(SettingsModel *)settingsModel

--- a/ios/screens/SettingsViewController/SettingsViewController.h
+++ b/ios/screens/SettingsViewController/SettingsViewController.h
@@ -15,11 +15,14 @@ NS_ASSUME_NONNULL_BEGIN
 @class SettingsModel;
 @class SettingsScreen;
 
-@interface SettingsViewController : UITableViewController<SettingsModelObserver, UserModelObserver>
+@interface SettingsViewController : UIViewController<SettingsModelObserver, UserModelObserver, UITableViewDelegate, UITableViewDataSource>
 
 - (instancetype)initWithSettingsController:(SettingsController *)settingsController
                              settingsModel:(SettingsModel *)settingsModel
                             settingsScreen:(SettingsScreen *)settingsScreen;
+
+- (instancetype)initWithSettingsController:(SettingsController *)settingsController
+                             settingsModel:(SettingsModel *)settingsModel;
 
 @end
 

--- a/ios/screens/SettingsViewController/SettingsViewController.h
+++ b/ios/screens/SettingsViewController/SettingsViewController.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "SettingsModelObserver.h"
+#import "UserModelObserver.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SettingsModel;
 @class SettingsScreen;
 
-@interface SettingsViewController : UITableViewController<SettingsModelObserver>
+@interface SettingsViewController : UITableViewController<SettingsModelObserver, UserModelObserver>
 
 - (instancetype)initWithSettingsController:(SettingsController *)settingsController
                              settingsModel:(SettingsModel *)settingsModel

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -204,6 +204,9 @@ static NSString * const kAuthCellId = @"authCellId";
                         toCurrentState:(UserModelState)currentState {
   // Find 4th tab controller in application.
   UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
+  if (tabController.viewControllers.count < 4) {
+    return;
+  }
   SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
   BOOL root = settingsViewController == self;
 

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -207,4 +207,24 @@ static NSString * const kAuthLoggedInCellId = @"authLoggedInCellId";
   [self.tableView reloadData];
 }
 
+- (void)onUserModelStateTransitionFrom:(UserModelState)prevState
+                        toCurrentState:(UserModelState)currentState {
+  // Find 4th tab controller in application.
+  UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
+  SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
+  BOOL root = settingsViewController == self;
+  
+  __weak typeof(self) weakSelf = self;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __weak typeof(self) strongSelf = weakSelf;
+      if (prevState == UserModelStateSignedIn &&
+          currentState == UserModelStateSignOutInProgress && !root) {
+        [strongSelf.navigationController popToRootViewControllerAnimated:YES];
+        return;
+      }
+    });
+  });
+}
+
 @end

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -184,6 +184,11 @@ static NSString * const kAuthCellId = @"authCellId";
   return YES;
 }
 
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+  SettingsGroup *group = self.root.groups[section];
+  return group.name;
+}
+
 - (void)onSettingsModelEntryChange:(nonnull SettingsEntry *)entry {
   [self.tableView reloadData];
 }

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -92,7 +92,7 @@ static NSString * const kAuthCellId = @"authCellId";
     [self.tableView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor],
     [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor],
   ]];
-  
+
   self.tableView.delegate = self;
   self.tableView.dataSource = self;
   [self.tableView registerClass:SettingsActionTableViewCell.self forCellReuseIdentifier:kActionCellId];
@@ -117,7 +117,7 @@ static NSString * const kAuthCellId = @"authCellId";
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.row];
-  
+
   if ([entry isKindOfClass:[SettingsEntryToggle class]]) {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kToggleCellId forIndexPath:indexPath];
     SettingsToggleTableViewCell *cellToggle = (SettingsToggleTableViewCell *) cell;
@@ -130,13 +130,17 @@ static NSString * const kAuthCellId = @"authCellId";
   }
   if ([entry isKindOfClass:[SettingsEntryAuthLoggedOut class]]) {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kAuthCellId forIndexPath:indexPath];
+    SettingsAuthTableViewCell *cellAuth = (SettingsAuthTableViewCell *)cell;
+    [cellAuth updateWithSubTitle:@"a" fetchingInProgress:NO signedIn:NO];
     return cell;
   }
   if ([entry isKindOfClass:[SettingsEntryAuthLoggedIn class]]) {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kAuthCellId forIndexPath:indexPath];
+    SettingsAuthTableViewCell *cellAuth = (SettingsAuthTableViewCell *)cell;
+    [cellAuth updateWithSubTitle:@"a" fetchingInProgress:NO signedIn:YES];
     return cell;
   }
-  
+
   SettingsBaseTableViewCell *baseCell = [tableView dequeueReusableCellWithIdentifier:kBaseCellId forIndexPath:indexPath];
   SettingsBaseTableViewCellConfig *config = [[SettingsBaseTableViewCellConfig alloc] initWithTitle:entry.name
                                                                                   subTitle:entry.value
@@ -147,7 +151,7 @@ static NSString * const kAuthCellId = @"authCellId";
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.section];
+  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.row];
   if ([entry isKindOfClass:[SettingsEntryAuthLoggedOut class]]) {
     return kAuthRowHeight;
   }
@@ -156,7 +160,7 @@ static NSString * const kAuthCellId = @"authCellId";
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
   [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
-  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.section];
+  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.row];
   if ([entry isKindOfClass:[SettingsEntryToggle class]]) {
     return;
   }
@@ -164,7 +168,7 @@ static NSString * const kAuthCellId = @"authCellId";
 }
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
-  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.section];
+  SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.row];
   if ([entry isKindOfClass:[SettingsEntryToggle class]]) {
     return NO;
   }
@@ -184,7 +188,7 @@ static NSString * const kAuthCellId = @"authCellId";
 }
 
 - (void)onSettingsModelScreenChange:(nonnull SettingsScreen *)screen {
-  
+
 }
 
 - (void)onUserModelStateTransitionFrom:(UserModelState)prevState
@@ -193,7 +197,7 @@ static NSString * const kAuthCellId = @"authCellId";
   UITabBarController *tabController = (UITabBarController *)[UIApplication sharedApplication].keyWindow.rootViewController;
   SettingsViewController *settingsViewController = (SettingsViewController *)tabController.viewControllers[3];
   BOOL root = settingsViewController == self;
-  
+
   __weak typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -15,12 +15,15 @@
 #import "SettingsEntrySelect.h"
 #import "SettingsEntryAction.h"
 #import "SettingsEntryNavigate.h"
-#import "SettingsEntryAuth.h"
+#import "SettingsEntryAuthLoggedOut.h"
+#import "SettingsEntryAuthLoggedIn.h"
 #import "SettingsActionTableViewCell.h"
 #import "SettingsNavigateTableViewCell.h"
 #import "SettingsSelectTableViewCell.h"
 #import "SettingsToggleTableViewCell.h"
 #import "SettingsBaseTableViewCell.h"
+#import "AuthLoggedInTableViewCell.h"
+#import "AuthLoggedOutTableViewCell.h"
 #import "SettingsBaseTableViewCellConfig.h"
 #import "Colors.h"
 #import "StyleUtils.h"
@@ -40,6 +43,8 @@ static NSString * const kToggleCellId = @"toggleCellId";
 static NSString * const kSelectCellId = @"selectCellId";
 static NSString * const kNavigateCellId = @"navigateCellId";
 static NSString * const kBaseCellId = @"baseCellId";
+static NSString * const kAuthLoggedOutCellId = @"authLoggedOutCellId";
+static NSString * const kAuthLoggedInCellId = @"authLoggedInCellId";
 
 @implementation SettingsViewController
 
@@ -101,6 +106,15 @@ static NSString * const kBaseCellId = @"baseCellId";
     [cellToggle update:entry.name enabled:entryToggle.enabled onToggle:^(BOOL enabled) {
       [weakSelf.settingsController interactWithSetting:entry onViewController:weakSelf];
     }];
+    return cellToggle;
+  }
+  if ([entry isKindOfClass:[SettingsEntryAuthLoggedOut class]]) {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kAuthLoggedOutCellId forIndexPath:indexPath];
+    return cell;
+  }
+  if ([entry isKindOfClass:[SettingsEntryAuthLoggedIn class]]) {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kAuthLoggedInCellId forIndexPath:indexPath];
+    return cell;
   }
   
   SettingsBaseTableViewCell *baseCell = [tableView dequeueReusableCellWithIdentifier:kBaseCellId forIndexPath:indexPath];
@@ -114,7 +128,7 @@ static NSString * const kBaseCellId = @"baseCellId";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
   SettingsEntry *entry = self.root.groups[indexPath.section].entries[indexPath.section];
-  if ([entry isKindOfClass:[SettingsEntryAuth class]]) {
+  if ([entry isKindOfClass:[SettingsEntryAuthLoggedOut class]]) {
     return kAuthRowHeight;
   }
   return kSettingsRowHeight;

--- a/ios/screens/SettingsViewController/SettingsViewController.m
+++ b/ios/screens/SettingsViewController/SettingsViewController.m
@@ -140,6 +140,15 @@ static NSString * const kAuthCellId = @"authCellId";
     [cellAuth updateWithSubTitle:@"a" fetchingInProgress:NO signedIn:YES];
     return cell;
   }
+  if ([entry isKindOfClass:[SettingsEntryNavigate class]]) {
+    SettingsBaseTableViewCell *baseCell = [tableView dequeueReusableCellWithIdentifier:kBaseCellId forIndexPath:indexPath];
+    SettingsBaseTableViewCellConfig *config = [[SettingsBaseTableViewCellConfig alloc] initWithTitle:entry.name
+                                                                                    subTitle:entry.value
+                                                                                    iconName:entry.iconName
+                                                                                    chevron:YES];
+    [baseCell update:config];
+    return baseCell;
+  }
 
   SettingsBaseTableViewCell *baseCell = [tableView dequeueReusableCellWithIdentifier:kBaseCellId forIndexPath:indexPath];
   SettingsBaseTableViewCellConfig *config = [[SettingsBaseTableViewCellConfig alloc] initWithTitle:entry.name

--- a/ios/utilities/LocaleUtils.h
+++ b/ios/utilities/LocaleUtils.h
@@ -10,6 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 NSString* getCurrentLocaleLanguageCode(void);
+NSString* getCurrentLocaleFriendlyName(void);
 BOOL isCurrentLanguageCodeLegacy(void);
 
 NS_ASSUME_NONNULL_END

--- a/ios/utilities/LocaleUtils.m
+++ b/ios/utilities/LocaleUtils.m
@@ -29,6 +29,16 @@ NSString* getCurrentLocaleLanguageCode() {
   return shortCode;
 }
 
+NSString* getCurrentLocaleFriendlyName() {
+  NSDictionary *codeToFriendlyName = @{
+    @"ru": NSLocalizedString(@"SettingsViewControllerLanguageCellValueRussian", @""),
+    @"en": NSLocalizedString(@"SettingsViewControllerLanguageCellValueEnglish", @""),
+    @"zh": NSLocalizedString(@"SettingsViewControllerLanguageCellValueChineseSimplified", @""),
+  };
+  NSString *code = getCurrentLocaleLanguageCode();
+  return codeToFriendlyName[code];
+}
+
 BOOL isCurrentLanguageCodeLegacy() {
   return [LocaleLanguageCodeLegacy isEqualToString:getCurrentLocaleLanguageCode()];
 }

--- a/ios/utilities/Typography.h
+++ b/ios/utilities/Typography.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSAttributedString *)makeProfileTableViewCellSubTextLabelForSettingsCell:(NSString *)input;
 - (NSAttributedString *)makeProfileTableViewCellMainTextLabelForAuthCell:(NSString *)input;
 - (NSAttributedString *)makeProfileTableViewCellSubTextLabelForAuthCell:(NSString *)input;
+- (NSAttributedString *)settingsCellTitle:(NSString *)input;
+- (NSAttributedString *)settingsCellSubTitle:(NSString *)input;
 
 @end
 

--- a/ios/utilities/Typography.m
+++ b/ios/utilities/Typography.m
@@ -77,6 +77,15 @@ static Typography *instance;
                                          attributes:getTextAttributes([Colors get].mainText, 13.0, UIFontWeightRegular)];
 }
 
+- (NSAttributedString *)settingsCellTitle:(NSString *)input {
+  return [[NSAttributedString alloc] initWithString:input
+                                         attributes:getTextAttributes([Colors get].mainText, 17.0, UIFontWeightRegular)];
+}
+
+- (NSAttributedString *)settingsCellSubTitle:(NSString *)input {
+  return [[NSAttributedString alloc] initWithString:input
+                                         attributes:getTextAttributes([Colors get].subText, 17.0, UIFontWeightRegular)];
+}
 
 + (instancetype)get {
     if (instance) {

--- a/ios/zh-Hans.lproj/Localizable.strings
+++ b/ios/zh-Hans.lproj/Localizable.strings
@@ -72,6 +72,14 @@
 "ProfileTableViewCellLabelLanguage" = "语";
 "ProfileTableViewCellLabelTheme" = "主题";
 
+//SettingsViewController
+"SettingsViewControllerAuthCellTitleAuthorized" = "您已获得授权";
+"SettingsViewControllerAuthCellTitleAuthorizedNot" = "你没有被授权";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "正在授权";
+
+"SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "授权或注册";
+"SettingsViewControllerAuthCellTitleAuthorizedProgress" = "等待登录验证";
+
 "CodeConfirmationScreenTitle" = "Подтверждение почты";
 "CodeConfirmationScreenTitle" = "Email confirmation";
 "CodeConfirmationScreenHeader" = "Confirm sign up";

--- a/ios/zh-Hans.lproj/Localizable.strings
+++ b/ios/zh-Hans.lproj/Localizable.strings
@@ -80,6 +80,7 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "授权或注册";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "等待登录验证";
 
+"SettingsViewControllerGeneralGroupTitle" = "设置";
 "SettingsViewControllerLanguageCellTitle" = "语言";
 "SettingsViewControllerLanguageCellValueEnglish" = "英语";
 "SettingsViewControllerLanguageCellValueRussian" = "俄语";
@@ -89,6 +90,7 @@
 "SettingsViewControllerCacheAlertMessageHeader" = "清除缓存？";
 "SettingsViewControllerCacheAlertMessageBody" = "这将减少应用程序的大小";
 
+"SettingsViewControllerAboutGroupTitle" = "信息";
 "SettingsViewControllerTermsCellTitle" = "条款和条件";
 "SettingsViewControllerPrivacyCellTitle" = "隐私政策";
 

--- a/ios/zh-Hans.lproj/Localizable.strings
+++ b/ios/zh-Hans.lproj/Localizable.strings
@@ -80,6 +80,18 @@
 "SettingsViewControllerAuthCellSubTitleAuthorizedNot" = "授权或注册";
 "SettingsViewControllerAuthCellTitleAuthorizedProgress" = "等待登录验证";
 
+"SettingsViewControllerLanguageCellTitle" = "语言";
+"SettingsViewControllerLanguageCellValueEnglish" = "英语";
+"SettingsViewControllerLanguageCellValueRussian" = "俄语";
+"SettingsViewControllerLanguageCellValueChineseSimplified" = "简体中文";
+
+"SettingsViewControllerCacheCellTitle" = "清除缓存";
+"SettingsViewControllerCacheAlertMessageHeader" = "清除缓存？";
+"SettingsViewControllerCacheAlertMessageBody" = "这将减少应用程序的大小";
+
+"SettingsViewControllerTermsCellTitle" = "条款和条件";
+"SettingsViewControllerPrivacyCellTitle" = "隐私政策";
+
 "CodeConfirmationScreenTitle" = "Подтверждение почты";
 "CodeConfirmationScreenTitle" = "Email confirmation";
 "CodeConfirmationScreenHeader" = "Confirm sign up";


### PR DESCRIPTION
### What does this PR do:

Adds UI based on `SettingsViewController` which understands `SettingsModel`.
This is intermediate work to enable settings view controller to be derived from settings model.

#### Ticket Links:
#638

#### Related PR(s):
#652 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
