### PR TITLE
feat(660): add ITSAppUsesNonExemptEncryption=false

### DIFF
--- a/ios/greenTravel/Info.plist
+++ b/ios/greenTravel/Info.plist
@@ -84,5 +84,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false />
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false />
 </dict>
 </plist>


### PR DESCRIPTION
### What does this PR do:

Adds Info.plist key to make compliance check easier.
<img width="331" alt="Screenshot 2023-01-25 at 18 16 02" src="https://user-images.githubusercontent.com/7137128/214601386-cb2aa111-682f-47b2-9f84-492b13a2f1d1.png">
https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption?language=objc

#### Ticket Links:
#660 

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
