### PR TITLE
fix(uikit): fix missused uikit methods

### DIFF
--- a/ios/screens/DetailsViewController/DetailsViewController.m
+++ b/ios/screens/DetailsViewController/DetailsViewController.m
@@ -290,7 +290,7 @@ static const CGFloat kDistanceScreenEdgeToTextContent = 16.0;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
-  [super viewWillDisappear:animated];
+  [super viewDidDisappear:animated];
   [[AnalyticsEvents get] logEvent:AnalyticsEventsDetailsBack withParams:@{
     AnalyticsEventsParamCardName: self.item.title,
     AnalyticsEventsParamCardCategory: self.item.category.title

--- a/ios/screens/MapViewController/BaseMapViewController.m
+++ b/ios/screens/MapViewController/BaseMapViewController.m
@@ -172,6 +172,7 @@ static CGFloat const kLocateMeZoomLevel = 10.0;
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
   [self saveMapCoordinates];
 }
 

--- a/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
+++ b/ios/screens/ProfileRootViewController/LoginViewController/BaseFormViewController.m
@@ -98,7 +98,7 @@ static const CGFloat kMinContentInset = 23.5;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
-  [super viewWillDisappear:animated];
+  [super viewDidDisappear:animated];
   [self.userModel removeUserModelObserver:self];
 }
 


### PR DESCRIPTION
Fix missued UIKit methods and remove console log warning

Radzima Dev[32474:11577474] [ViewController] Calling -viewWillDisappear: directly on a view controller is not supported, and may result in out-of-order callbacks and other inconsistent behavior. Use the -beginAppearanceTransition:animated: and -endAppearanceTransition APIs on UIViewController to manually drive appearance callbacks instead. Make a symbolic breakpoint at UIViewControllerAlertForAppearanceCallbackMisuse to catch this in the debugger. View controller: <DetailsViewController: 0x11086e000>