### PR TITLE
[489] disable button for invalid password

### DIFF
--- a/src/screens/NewPassword/hooks/useNewPassword.tsx
+++ b/src/screens/NewPassword/hooks/useNewPassword.tsx
@@ -74,7 +74,7 @@ export const useNewPassword = () => {
     rightIcon,
     passwordVisibility,
     handlePasswordVisibility,
-    isSubmitButtonDisabled: !formik.values.password,
+    isSubmitButtonDisabled: !formik.isValid,
     submitForm: formik.handleSubmit,
     snackBarProps,
   };


### PR DESCRIPTION
### What does this PR do:

Disable button for invalid password

#### Visual change - screenshot after:

![Screenshot 2023-06-16 at 17 27 25](https://github.com/radzima-green-travel/green-travel-combine/assets/70779585/a1214fde-7f5b-4d5a-a78e-10ba0aafcea4)


#### Ticket Links:
[489](https://jira.epam.com/jira/browse/EPMEDUGRN-489)