### PR TITLE
fix(489): save button state

### DIFF
--- a/src/screens/NewPassword/hooks/useNewPassword.tsx
+++ b/src/screens/NewPassword/hooks/useNewPassword.tsx
@@ -74,7 +74,7 @@ export const useNewPassword = () => {
     rightIcon,
     passwordVisibility,
     handlePasswordVisibility,
-    isSubmitButtonDisabled: !formik.isValid,
+    isSubmitButtonDisabled: !formik.isValid || !formik.values.password,
     submitForm: formik.handleSubmit,
     snackBarProps,
   };


### PR DESCRIPTION
### What does this PR do:

Fix disabling save button when the password field is empty.

#### Visual change - screenshot before:
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-06-23 at 13 08 56](https://github.com/radzima-green-travel/green-travel-combine/assets/82803292/07eb878f-a1fa-4fa6-b108-1fb5a2d8b914)

#### Visual change - screenshot after:
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-06-23 at 13 08 46](https://github.com/radzima-green-travel/green-travel-combine/assets/82803292/aa86cc5c-0494-46b1-a619-93f281397318)

#### Ticket Links:
[489](https://jira.epam.com/jira/browse/EPMEDUGRN-489)
