### PR TITLE
fix(fixed): [614] translation for copy location

### DIFF
--- a/src/components/molecules/DetailsPageCapture/DetailsPageCapture.tsx
+++ b/src/components/molecules/DetailsPageCapture/DetailsPageCapture.tsx
@@ -93,7 +93,7 @@ export const DetailsPageCapture = memo(
             <Text
               style={[styles.location, styles.copyLocation]}
               {...getPlatformsTestID(TestIDs.ObjectDetailsLocation)}>
-              {'Copy location'}
+              {t('copyLocation')}
             </Text>
           </TouchableOpacity>
         ) : null}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -58,7 +58,8 @@
     "objectNotFoundText": "Try to search object on the Main page.",
     "objectNotFoundButtonText": "Go to Main page",
     "aboutRoute": "About route",
-    "aboutObject": "About place"
+    "aboutObject": "About place",
+    "copyLocation": "Copy location"
   },
   "bookmarks": {
     "emptyText": "Nothing is saved for now"

--- a/src/locale/ru.json
+++ b/src/locale/ru.json
@@ -25,8 +25,8 @@
     "locationPermissionCancel": "Отменить",
     "locationPermissionSetttings": "Настройки",
     "cancel": "Отмена",
-    "privacyPolicy": "Политика конфиденциальности",
-    "termsAndConditions": "Условия использования",
+    "privacyPolicy": "Политикой конфиденциальности",
+    "termsAndConditions": "Условиями использования",
     "appVersion": "Версия приложения:"
   },
   "home": {

--- a/src/locale/ru.json
+++ b/src/locale/ru.json
@@ -58,7 +58,8 @@
     "objectNotFoundText": "Попробуйте найти объект с помощью главной страницы.",
     "objectNotFoundButtonText": "Перейти на главную",
     "aboutRoute": "О маршруте",
-    "aboutObject": "О месте"
+    "aboutObject": "О месте",
+    "copyLocation": "Скопировать координаты"
   },
   "bookmarks": {
     "emptyText": "Вы пока ничего сюда не добавили"


### PR DESCRIPTION
### What does this PR do:

Add translation for copy location text

#### Visual change - screenshot after:
![Screenshot 2023-11-15 at 11 41 45](https://github.com/radzima-green-travel/green-travel-combine/assets/70779585/833ab7cb-5904-4bde-a95e-fa072a72695c)

![Screenshot 2023-11-15 at 11 41 56](https://github.com/radzima-green-travel/green-travel-combine/assets/70779585/d1f2ea26-00fb-4d46-8a2e-90d5a27dec70)

![Screenshot 2023-11-15 at 11 51 34](https://github.com/radzima-green-travel/green-travel-combine/assets/70779585/1d720439-9784-4561-92c9-1ea94673eee9)

#### Ticket Links:
[614](https://jira.epam.com/jira/browse/EPMEDUGRN-614).

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
