### PR TITLE
feat(728): disable screen touchability when loading is true

### DIFF
--- a/src/screens/ObjectDetailsAddInfo/ObjectDetailsAddInfo.tsx
+++ b/src/screens/ObjectDetailsAddInfo/ObjectDetailsAddInfo.tsx
@@ -72,7 +72,9 @@ export const ObjectDetailsAddInfo = () => {
   const {bottom} = useSafeAreaInsets();
 
   return (
-    <View style={styles.container}>
+    <View
+      style={styles.container}
+      pointerEvents={isSendLoading ? 'none' : 'auto'}>
       <View
         style={[
           styles.header,

--- a/src/screens/ObjectDetailsAddInfo/hooks/useObjectDetailsAddInfo.ts
+++ b/src/screens/ObjectDetailsAddInfo/hooks/useObjectDetailsAddInfo.ts
@@ -107,15 +107,6 @@ export const useObjectDetailsAddInfo = () => {
     }
   };
 
-  useBackHandler(() => {
-    if (getIsDataCanBeLost() && confirmBottomMenuProps.isMenuClosed()) {
-      confirmBottomMenuProps.openMenu();
-      return true;
-    }
-
-    return false;
-  });
-
   const onSendPress = useCallback(() => {
     if (objectId && objectName) {
       const {message, fields} = getEmailContents();
@@ -153,6 +144,19 @@ export const useObjectDetailsAddInfo = () => {
       });
     },
   );
+
+  useBackHandler(() => {
+    if (isSendLoading) {
+      return true;
+    }
+
+    if (getIsDataCanBeLost() && confirmBottomMenuProps.isMenuClosed()) {
+      confirmBottomMenuProps.openMenu();
+      return true;
+    }
+
+    return false;
+  });
 
   return {
     name: objectName,


### PR DESCRIPTION
### What does this PR do:

Fix ObjectDetailsAddInfo issue when entered information gets lost if users click Back on Suggest new info screen by adding a new modal window

#### Visual change - screenshot before:

<Details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/b519adc1-aeb1-42a6-b30c-cccc7e37ce5a

</Details>


#### Visual change - screenshot after:

<Details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/654f6d62-9508-4166-a987-7ffbda614753

</Details>


#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-728

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA

