### PR TITLE
feat(740): add disable for submit button for ObjectAddInfoMenu

### DIFF
--- a/src/components/molecules/ObjectAddInfoMenu/ObjectAddInfoMenu.tsx
+++ b/src/components/molecules/ObjectAddInfoMenu/ObjectAddInfoMenu.tsx
@@ -89,9 +89,10 @@ export const ObjectAddInfoMenu = memo(
             theme: 'primary' as const,
             testID: composeTestID(testID, 'submitButton'),
             text: t('ready'),
+            disabled: !value,
           },
         ];
-      }, [onSubmitForm, t, testID]);
+      }, [onSubmitForm, t, testID, value]);
 
       const {bottom} = useSafeAreaInsets();
 


### PR DESCRIPTION
### What does this PR do:

Add disable for submit button for ObjectAddInfoMenu

#### Visual change - screenshot before:

<details>
https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/616a54c5-62db-4ecb-a139-15949ae6b396
</details>


#### Visual change - screenshot after:

<details>
https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/d6192bb0-7ff6-4401-b298-a1ca7564ea0e
</details>


#### Ticket Links:
<!-- Link to the ticket in GitHub -->

#### Related PR(s):

https://jira.epam.com/jira/browse/EPMEDUGRN-740

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
