### PR TITLE
fix(750): update translations for dinerPlaces

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -140,7 +140,7 @@
     "ready": "Done",
     "prompts": {
       "upcomingEvents": "Please provide its name, date and website",
-      "dinnerPlaces": "The nearest place to have a dinner",
+      "dinnerPlaces": "Please provide its name, Google Maps link or its website",
       "accommodationPlace": "Please provide its name, Google Maps link or its website",
       "workingHours": "Please enter working hours",
       "childServices": "Which services for kids are available?",


### PR DESCRIPTION
### What does this PR do:

Update translations for dinerPlaces

#### Visual change - screenshot before:

<details>
<img width="372" alt="Снимок экрана 2024-05-09 в 08 23 03" src="https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/5f1c304a-6804-4709-8dae-3dd01d2183dd">
</details>

#### Visual change - screenshot after:

<details>
<img width="372" alt="Снимок экрана 2024-05-09 в 08 22 29" src="https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/2f0158c1-8c10-4183-8f37-de4d97f525b3">
</details>

#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-750

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA
