### PR TITLE
fix(0000): update position for phone number

### DIFF
--- a/src/screens/ObjectDetails/hooks/useObjectDetailsInfo.ts
+++ b/src/screens/ObjectDetails/hooks/useObjectDetailsInfo.ts
@@ -139,12 +139,6 @@ export function useObjectDetailsInfo() {
         leadIcon: 'globe',
         testID: TestIDs.ObjectDetailsOfficialWebsite,
       },
-      getAttendaceStringTime && {
-        subtitle: t('objectFieldsLabels.attendanceTime'),
-        title: getAttendaceStringTime,
-        leadIcon: 'hourglass',
-        testID: TestIDs.ObjectDetailsAttendanceTime,
-      },
       phoneNumbers?.length && {
         subtitle: t('objectFieldsLabels.phoneNumber'),
         title: phoneNumbers[0],
@@ -160,6 +154,12 @@ export function useObjectDetailsInfo() {
           openPhoneNumbersMenu();
           sendMorePhonesViewEvent();
         },
+      },
+      getAttendaceStringTime && {
+        subtitle: t('objectFieldsLabels.attendanceTime'),
+        title: getAttendaceStringTime,
+        leadIcon: 'hourglass',
+        testID: TestIDs.ObjectDetailsAttendanceTime,
       },
     ] as Item[]);
   }, [


### PR DESCRIPTION
### What does this PR do:

'Phone number' located under 'Official website' field instead 'Average visit time' field.

#### Visual change - screenshot before:

<details>
<img width="365" alt="Снимок экрана 2024-05-16 в 15 58 31" src="https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/4d60b9cf-be09-44cb-b7ad-6ac8453dc89d">
</details>

#### Visual change - screenshot after:

<details>
<img width="365" alt="Снимок экрана 2024-05-16 в 15 57 51" src="https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/5c35ad54-d16d-4552-9329-65a16988fae6">
</details>

#### Ticket Links:
<!-- Link to the ticket in GitHub -->

https://plus.epam.com/task/26021

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA
