### PR TITLE
fix(742): fix field order mismatch by design

### DIFF
--- a/src/components/molecules/ObjectAddInfoMenu/ObjectAddInfoMenu.tsx
+++ b/src/components/molecules/ObjectAddInfoMenu/ObjectAddInfoMenu.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {TextInput, View, StatusBar} from 'react-native';
@@ -52,6 +53,7 @@ export const ObjectAddInfoMenu = memo(
       const isTimePickerField = TIME_PICKER_FIELDS.has(currentField);
 
       const [value, setValue] = useState(formValue);
+      const initialValue = useRef(formValue);
 
       useEffect(() => {
         setValue(formValue);
@@ -101,7 +103,7 @@ export const ObjectAddInfoMenu = memo(
             theme: 'primary' as const,
             testID: composeTestID(testID, 'submitButton'),
             text: t('ready'),
-            disabled: !value,
+            disabled: !value && !initialValue.current,
           },
         ];
       }, [onSubmitForm, t, testID, value]);


### PR DESCRIPTION
### What does this PR do:

This PR makes the 'Done' button clickable if after was initially filled in after removing the value

#### Visual change - screenshot before:

<details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/f7efec2c-3197-4485-86d5-5ff67e6872e6

</details>


#### Visual change - screenshot after:

<details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/33baaf6e-8ed3-429f-957b-c5627ed4038b

</details>


#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-742

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA
