### PR TITLE
fix(748): part of the previous card is invisible while scrolling

### DIFF
--- a/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
+++ b/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
@@ -1,7 +1,7 @@
 import React, {memo, useCallback, useRef, useEffect, useMemo} from 'react';
 import {View, Text, TouchableOpacity, FlatList} from 'react-native';
 import {ObjectCard, CategoryCard} from 'molecules';
-import {themeStyles, cardWidth, getSnapToOffsets} from './styles';
+import {themeStyles, cardWidth, SNAP_INTERVAL} from './styles';
 import {useTranslation} from 'react-i18next';
 import {IObject, ITransformedCategory, TestIDs} from 'core/types';
 import {isEmpty} from 'lodash';
@@ -81,13 +81,12 @@ export const HomeSectionBar = memo(
       listRef.current?.scrollToOffset({animated: true, offset: 0});
     }, [childrenData, objectsData]);
 
-    const snapToOffsetsForChildrenData = useMemo(() => {
-      return getSnapToOffsets(childrenData);
-    }, [childrenData]);
-
     const snapToOffsets = useMemo(() => {
-      return getSnapToOffsets(objectsData);
-    }, [objectsData]);
+      const data = isCategoriesList ? childrenData : objectsData;
+      return data.map((_, index) => {
+        return index * SNAP_INTERVAL - 8;
+      });
+    }, [childrenData, isCategoriesList, objectsData]);
 
     return (
       <View>
@@ -110,7 +109,7 @@ export const HomeSectionBar = memo(
         {isCategoriesList ? (
           <FlatList
             ref={listRef}
-            snapToOffsets={snapToOffsetsForChildrenData}
+            snapToOffsets={snapToOffsets}
             snapToStart={false}
             decelerationRate="fast"
             keyExtractor={({id}) => id}

--- a/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
+++ b/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
@@ -1,7 +1,7 @@
 import React, {memo, useCallback, useRef, useEffect} from 'react';
 import {View, Text, TouchableOpacity, FlatList} from 'react-native';
 import {ObjectCard, CategoryCard} from 'molecules';
-import {themeStyles, cardWidth, SNAP_INTERVAL} from './styles';
+import {themeStyles, cardWidth, getSnapToOffsets} from './styles';
 import {useTranslation} from 'react-i18next';
 import {IObject, ITransformedCategory, TestIDs} from 'core/types';
 import {isEmpty} from 'lodash';
@@ -102,7 +102,7 @@ export const HomeSectionBar = memo(
         {isCategoriesList ? (
           <FlatList
             ref={listRef}
-            snapToInterval={SNAP_INTERVAL}
+            snapToOffsets={getSnapToOffsets(childrenData)}
             snapToStart={false}
             decelerationRate="fast"
             keyExtractor={({id}) => id}
@@ -125,7 +125,7 @@ export const HomeSectionBar = memo(
           <FlatList
             ref={listRef}
             keyExtractor={({id}) => id}
-            snapToInterval={SNAP_INTERVAL}
+            snapToOffsets={getSnapToOffsets(objectsData)}
             snapToStart={false}
             decelerationRate="fast"
             style={styles.container}

--- a/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
+++ b/src/components/organisms/HomeSectionBar/HomeSectionBar.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useRef, useEffect} from 'react';
+import React, {memo, useCallback, useRef, useEffect, useMemo} from 'react';
 import {View, Text, TouchableOpacity, FlatList} from 'react-native';
 import {ObjectCard, CategoryCard} from 'molecules';
 import {themeStyles, cardWidth, getSnapToOffsets} from './styles';
@@ -81,6 +81,14 @@ export const HomeSectionBar = memo(
       listRef.current?.scrollToOffset({animated: true, offset: 0});
     }, [childrenData, objectsData]);
 
+    const snapToOffsetsForChildrenData = useMemo(() => {
+      return getSnapToOffsets(childrenData);
+    }, [childrenData]);
+
+    const snapToOffsets = useMemo(() => {
+      return getSnapToOffsets(objectsData);
+    }, [objectsData]);
+
     return (
       <View>
         <View style={styles.sectionTitleContainer}>
@@ -102,7 +110,7 @@ export const HomeSectionBar = memo(
         {isCategoriesList ? (
           <FlatList
             ref={listRef}
-            snapToOffsets={getSnapToOffsets(childrenData)}
+            snapToOffsets={snapToOffsetsForChildrenData}
             snapToStart={false}
             decelerationRate="fast"
             keyExtractor={({id}) => id}
@@ -125,7 +133,7 @@ export const HomeSectionBar = memo(
           <FlatList
             ref={listRef}
             keyExtractor={({id}) => id}
-            snapToOffsets={getSnapToOffsets(objectsData)}
+            snapToOffsets={snapToOffsets}
             snapToStart={false}
             decelerationRate="fast"
             style={styles.container}

--- a/src/components/organisms/HomeSectionBar/styles.ts
+++ b/src/components/organisms/HomeSectionBar/styles.ts
@@ -8,7 +8,13 @@ export const cardWidth = Math.round(
 );
 
 export const cardHeihgt = cardWidth / ratio;
-export const SNAP_INTERVAL = cardWidth + PADDING_HORIZONTAL;
+const SNAP_INTERVAL = cardWidth + PADDING_HORIZONTAL;
+
+export const getSnapToOffsets = data => {
+  return data.map((_, index) => {
+    return index * SNAP_INTERVAL - 8;
+  });
+};
 
 export const themeStyles = {
   container: {
@@ -16,7 +22,6 @@ export const themeStyles = {
     marginTop: 16,
   },
   contentContainer: {
-    paddingLeft: 1,
     paddingRight: 16,
     paddingBottom: 24,
     height: cardHeihgt + 24,

--- a/src/components/organisms/HomeSectionBar/styles.ts
+++ b/src/components/organisms/HomeSectionBar/styles.ts
@@ -3,7 +3,10 @@ import {PADDING_HORIZONTAL} from 'core/constants';
 import {SCREEN_WIDTH} from 'services/PlatformService';
 import {ratio} from 'atoms/Card/Card';
 
-export const cardWidth = (SCREEN_WIDTH - PADDING_HORIZONTAL * 2) * 0.945;
+export const cardWidth = Math.round(
+  (SCREEN_WIDTH - PADDING_HORIZONTAL * 2) * 0.945,
+);
+
 export const cardHeihgt = cardWidth / ratio;
 export const SNAP_INTERVAL = cardWidth + PADDING_HORIZONTAL;
 
@@ -13,6 +16,7 @@ export const themeStyles = {
     marginTop: 16,
   },
   contentContainer: {
+    paddingLeft: 1,
     paddingRight: 16,
     paddingBottom: 24,
     height: cardHeihgt + 24,

--- a/src/components/organisms/HomeSectionBar/styles.ts
+++ b/src/components/organisms/HomeSectionBar/styles.ts
@@ -8,13 +8,7 @@ export const cardWidth = Math.round(
 );
 
 export const cardHeihgt = cardWidth / ratio;
-const SNAP_INTERVAL = cardWidth + PADDING_HORIZONTAL;
-
-export const getSnapToOffsets = data => {
-  return data.map((_, index) => {
-    return index * SNAP_INTERVAL - 8;
-  });
-};
+export const SNAP_INTERVAL = cardWidth + PADDING_HORIZONTAL;
 
 export const themeStyles = {
   container: {


### PR DESCRIPTION
### What does this PR do:

Part of the previous card is invisible while scrolling

#### Visual change - screenshot before:

<details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/d0a54a03-0353-42f6-be99-c36b480a22e8

</details>

#### Visual change - screenshot after:

<details>

https://github.com/radzima-green-travel/green-travel-combine/assets/68128028/3e77fa65-5bb4-4f9d-bc11-02f340976196

</details>

#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-748

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA
