### PR TITLE
feat(migration): migrate Home page to GraphQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.1",
     "@react-navigation/stack": "^6.3.4",
+    "@reduxjs/toolkit": "^2.2.5",
     "@rnmapbox/maps": "^10.1.23",
     "@sentry/react-native": "~5.20.0",
     "@turf/distance": "^6.5.0",

--- a/src/api/graphql/GraphQLAPI.ts
+++ b/src/api/graphql/GraphQLAPI.ts
@@ -1,5 +1,37 @@
+import {
+  ListCategoriesResponseDTO,
+  ListShortObjectsResponseDTO,
+} from 'core/types/api';
 import {GraphQLAPIEngine} from './GraphQLAPIEngine';
+import {listCategoriesQuery, listObjectsShortQuery} from './queries';
 
-class GraphQLAPI extends GraphQLAPIEngine {}
+class GraphQLAPI extends GraphQLAPIEngine {
+  async getListCategories(): Promise<ListCategoriesResponseDTO> {
+    const response = await this.executeQuery({
+      query: listCategoriesQuery,
+    });
+    return response.listCategories;
+  }
+
+  async getShortObjectList({
+    categoryId,
+  }: {
+    categoryId: string;
+  }): Promise<ListShortObjectsResponseDTO> {
+    const response = await this.executeQuery({
+      query: listObjectsShortQuery,
+      params: {
+        limit: 10,
+        filter: {
+          status: {eq: 'published'},
+          categoryId: {
+            eq: categoryId,
+          },
+        },
+      },
+    });
+    return response.searchObjects;
+  }
+}
 
 export const graphQLAPI = new GraphQLAPI();

--- a/src/api/graphql/GraphQLAPI.ts
+++ b/src/api/graphql/GraphQLAPI.ts
@@ -1,9 +1,14 @@
 import {
+  CategoriesAggregationsByObjectsResponseDTO,
   ListCategoriesResponseDTO,
   ListShortObjectsResponseDTO,
 } from 'core/types/api';
 import {GraphQLAPIEngine} from './GraphQLAPIEngine';
-import {listCategoriesQuery, listObjectsShortQuery} from './queries';
+import {
+  listCategoriesQuery,
+  listObjectsShortQuery,
+  getCategoriesAggregationsByObjectsQuery,
+} from './queries';
 
 class GraphQLAPI extends GraphQLAPIEngine {
   async getListCategories(): Promise<ListCategoriesResponseDTO> {
@@ -31,6 +36,14 @@ class GraphQLAPI extends GraphQLAPIEngine {
       },
     });
     return response.searchObjects;
+  }
+
+  async getCategoriesAggregationsByObjects(): Promise<CategoriesAggregationsByObjectsResponseDTO> {
+    const response = await this.executeQuery({
+      query: getCategoriesAggregationsByObjectsQuery,
+    });
+    return response.filterLandingObjects?.aggregations?.categories?.facets
+      ?.buckets;
   }
 }
 

--- a/src/api/graphql/queries.ts
+++ b/src/api/graphql/queries.ts
@@ -33,3 +33,20 @@ export const listObjectsShortQuery = `query MyQuery($limit: Int = 10, $filter: S
   }
 }
 `;
+
+export const getCategoriesAggregationsByObjectsQuery = `query MyQuery {
+  filterLandingObjects(filter: {statuses: "published"}) {
+    aggregations {
+      categories {
+        doc_count
+        facets {
+          buckets {
+            doc_count
+            key
+          }
+        }
+      }
+    }
+  }
+}
+`;

--- a/src/api/graphql/queries.ts
+++ b/src/api/graphql/queries.ts
@@ -19,6 +19,7 @@ export const listObjectsShortQuery = `query MyQuery($limit: Int = 10, $filter: S
   searchObjects(limit: $limit, filter: $filter) {
     items {
       cover
+      blurhash
       category {
         name
       }

--- a/src/api/graphql/queries.ts
+++ b/src/api/graphql/queries.ts
@@ -1,0 +1,35 @@
+export const listCategoriesQuery = `query MyQuery($filter: ModelCategoryFilterInput = {}) {
+  listCategories(limit: 200, filter: $filter) {
+    items {
+      name
+      parent
+      index
+      id
+      cover
+      i18n {
+        name
+        locale
+      }
+    }
+  }
+}
+`;
+
+export const listObjectsShortQuery = `query MyQuery($limit: Int = 10, $filter: SearchableObjectFilterInput = {}) {
+  searchObjects(limit: $limit, filter: $filter) {
+    items {
+      cover
+      category {
+        name
+      }
+      i18n {
+        name
+        locale
+      }
+      name
+      categoryId
+      id
+    }
+  }
+}
+`;

--- a/src/api/graphql/queries.ts
+++ b/src/api/graphql/queries.ts
@@ -6,6 +6,7 @@ export const listCategoriesQuery = `query MyQuery($filter: ModelCategoryFilterIn
       index
       id
       cover
+      blurhash
       i18n {
         name
         locale

--- a/src/components/atoms/BottomMenu/BottomMenu.tsx
+++ b/src/components/atoms/BottomMenu/BottomMenu.tsx
@@ -19,7 +19,7 @@ import React, {
   memo,
   useState,
 } from 'react';
-import {AnimatedCircleButton} from 'molecules';
+import {AnimatedCircleButton} from 'molecules/AnimatedCircleButton';
 import {composeTestID} from 'core/helpers';
 import {uniqueId} from 'lodash';
 

--- a/src/components/atoms/Card/Card.tsx
+++ b/src/components/atoms/Card/Card.tsx
@@ -7,7 +7,7 @@ import {
   ViewStyle,
   ImageStyle,
 } from 'react-native';
-import {Icon} from 'atoms';
+import {Icon} from 'atoms/Icon';
 import {themeStyles, gradientConfig} from './styles';
 import {LinearGradient} from 'expo-linear-gradient';
 import {FavoriteButtonContainer} from '../../containers';

--- a/src/components/atoms/SnackBar/SnackBar.tsx
+++ b/src/components/atoms/SnackBar/SnackBar.tsx
@@ -5,7 +5,8 @@ import {themeStyles} from './styles';
 import {SnackBarContainer, SnackBarContainerRef} from './SnackBarContainer';
 
 import {useThemeStyles} from 'core/hooks';
-import {Button, Icon} from 'atoms';
+import {Button} from 'atoms/Button';
+import {Icon} from 'atoms/Icon';
 import {isEqual} from 'lodash';
 
 export interface SnackBarProps {

--- a/src/components/molecules/AnimatedCircleButton/AnimatedCircleButton.tsx
+++ b/src/components/molecules/AnimatedCircleButton/AnimatedCircleButton.tsx
@@ -1,9 +1,8 @@
-import {Icon} from 'atoms';
 import {useThemeStyles} from 'core/hooks';
 import React, {memo} from 'react';
 import {View, TouchableOpacity, StyleProp, ViewStyle} from 'react-native';
 import {themeStyles} from './styles';
-import {IconProps} from 'atoms/Icon';
+import {IconProps, Icon} from 'atoms/Icon';
 import Animated from 'react-native-reanimated';
 interface IProps {
   style?: StyleProp<ViewStyle>;

--- a/src/components/molecules/CategoryCard/CategoryCard.tsx
+++ b/src/components/molecules/CategoryCard/CategoryCard.tsx
@@ -1,11 +1,11 @@
 import {Card} from 'atoms';
-import {ITransformedCategory} from 'core/types';
+import {CardItem} from 'core/types';
 import React, {memo, useCallback} from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
 
 interface IProps {
-  data: ITransformedCategory;
-  onPress: (item: ITransformedCategory) => void;
+  data: CardItem;
+  onPress: (item: CardItem) => void;
   width: number;
   testID: string;
   containerStyle?: StyleProp<ViewStyle>;

--- a/src/components/molecules/ObjectCard/ObjectCard.tsx
+++ b/src/components/molecules/ObjectCard/ObjectCard.tsx
@@ -1,15 +1,15 @@
 import {Card} from 'atoms';
-import {IObject} from 'core/types';
+import {CardItem} from 'core/types';
 import React, {memo, useCallback} from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
 interface IProps {
-  data: IObject;
-  onPress: (item: IObject) => void;
+  data: CardItem;
+  onPress: (item: CardItem) => void;
   width: number;
   containerStyle?: StyleProp<ViewStyle>;
   removeFavoriteWithAnimation?: boolean;
   onRemoveAnimationEnd?: () => void;
-  onFavoriteChanged?: (item: IObject, nextIsFavorite: boolean) => void;
+  onFavoriteChanged?: (item: CardItem, nextIsFavorite: boolean) => void;
   testID: string;
 }
 

--- a/src/core/actions/home.ts
+++ b/src/core/actions/home.ts
@@ -1,0 +1,18 @@
+import {createAsyncAction} from 'core/helpers';
+import {CategoryShortDTO, ObjectShortDTO} from 'core/types/api';
+
+export const getHomePageDataRequest = createAsyncAction<
+  void,
+  {
+    categoriesList: Array<CategoryShortDTO>;
+    objectsByCategory: Record<string, ObjectShortDTO[]>;
+  }
+>('GET_HOME_PAGE_DATA');
+
+export const refreshHomePageDataRequest = createAsyncAction<
+  void,
+  {
+    categoriesList: Array<CategoryShortDTO>;
+    objectsByCategory: Record<string, ObjectShortDTO[]>;
+  }
+>('REFRESH_HOME_PAGE_DATA');

--- a/src/core/actions/index.ts
+++ b/src/core/actions/index.ts
@@ -1,0 +1,1 @@
+export * from './home';

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -5,3 +5,4 @@ export * from './getPlatformsTestID';
 export * from './getAppVersion';
 export * from './date';
 export * from './analytics';
+export * from './redux';

--- a/src/core/helpers/redux.ts
+++ b/src/core/helpers/redux.ts
@@ -1,0 +1,32 @@
+import {createAction} from '@reduxjs/toolkit';
+import {RequestError} from 'core/errors';
+
+export function createAsyncAction<
+  RequestPayload = void,
+  SuccessPayload = void,
+  FailurePayload = RequestError,
+  T extends string = string,
+>(type: T) {
+  const meta = {
+    successAction: createAction<SuccessPayload>(type + '_SUCCESS'),
+    failureAction: createAction<FailurePayload>(type + '_FAILURE'),
+  };
+  const asyncAction = createAction(
+    type + '_REQUEST',
+    (payload: RequestPayload) => ({
+      payload,
+      meta,
+    }),
+  );
+
+  function asyncActionWithStaticMeta(
+    ...args: Parameters<typeof asyncAction>
+  ): ReturnType<typeof asyncAction> {
+    return asyncAction(...args);
+  }
+  asyncActionWithStaticMeta.toString = asyncAction.toString;
+  asyncActionWithStaticMeta.type = asyncAction.type;
+  asyncActionWithStaticMeta.meta = meta;
+
+  return asyncActionWithStaticMeta;
+}

--- a/src/core/reducers/HomeReducer.ts
+++ b/src/core/reducers/HomeReducer.ts
@@ -2,16 +2,22 @@ import {createAction, createReducer, ActionType} from 'typesafe-actions';
 import {ILabelError} from '../types';
 import {ACTIONS} from '../constants';
 import {ListMobileDataQuery} from 'api/graphql/types';
+import type {CategoryShortDTO, ObjectShortDTO} from 'core/types/api';
 interface IDefaultState {
   currentData: ListMobileDataQuery | null;
   updatedData: ListMobileDataQuery | null;
   isUpdatesAvailable: boolean;
+  categoriesList: Array<CategoryShortDTO>;
+  objectsByCategory: Record<string, ObjectShortDTO>;
 }
 
 const initialState: IDefaultState = {
   currentData: null,
   updatedData: null,
   isUpdatesAvailable: false,
+
+  categoriesList: [],
+  objectsByCategory: {},
 };
 
 export const getInitialHomeDataRequest = createAction(

--- a/src/core/reducers/HomeReducer.ts
+++ b/src/core/reducers/HomeReducer.ts
@@ -2,22 +2,16 @@ import {createAction, createReducer, ActionType} from 'typesafe-actions';
 import {ILabelError} from '../types';
 import {ACTIONS} from '../constants';
 import {ListMobileDataQuery} from 'api/graphql/types';
-import type {CategoryShortDTO, ObjectShortDTO} from 'core/types/api';
 interface IDefaultState {
   currentData: ListMobileDataQuery | null;
   updatedData: ListMobileDataQuery | null;
   isUpdatesAvailable: boolean;
-  categoriesList: Array<CategoryShortDTO>;
-  objectsByCategory: Record<string, ObjectShortDTO>;
 }
 
 const initialState: IDefaultState = {
   currentData: null,
   updatedData: null,
   isUpdatesAvailable: false,
-
-  categoriesList: [],
-  objectsByCategory: {},
 };
 
 export const getInitialHomeDataRequest = createAction(

--- a/src/core/reducers/home.ts
+++ b/src/core/reducers/home.ts
@@ -1,0 +1,30 @@
+import {createReducer, isAnyOf} from '@reduxjs/toolkit';
+import {
+  getHomePageDataRequest,
+  refreshHomePageDataRequest,
+} from 'core/actions/home';
+import type {CategoryShortDTO, ObjectShortDTO} from 'core/types/api';
+
+interface HomePageState {
+  categoriesList: Array<CategoryShortDTO>;
+  objectsByCategory: Record<string, ObjectShortDTO[]>;
+}
+
+const initialState: HomePageState = {
+  categoriesList: [],
+  objectsByCategory: {},
+};
+
+export const homePageReducer = createReducer(initialState, builder => {
+  builder.addMatcher(
+    isAnyOf(
+      getHomePageDataRequest.meta.successAction,
+      refreshHomePageDataRequest.meta.successAction,
+    ),
+    (state, {payload}) => ({
+      ...state,
+      categoriesList: payload.categoriesList,
+      objectsByCategory: payload.objectsByCategory,
+    }),
+  );
+});

--- a/src/core/reducers/index.ts
+++ b/src/core/reducers/index.ts
@@ -7,3 +7,4 @@ export * from './AuthenticationReducer';
 export * from './SettingsReducer';
 export * from './AppConfigurationReducer';
 export * from './VisitedObjectsReducer';
+export * from './home';

--- a/src/core/rootSaga.ts
+++ b/src/core/rootSaga.ts
@@ -9,6 +9,7 @@ import {
   appSaga,
   visitedObjectsSaga,
   analytics,
+  homePageSaga,
 } from './sagas';
 
 export function* rootSaga() {
@@ -22,5 +23,6 @@ export function* rootSaga() {
     appSaga(),
     visitedObjectsSaga(),
     analytics(),
+    homePageSaga(),
   ]);
 }

--- a/src/core/sagas/bootstrap/bootstrap.ts
+++ b/src/core/sagas/bootstrap/bootstrap.ts
@@ -22,6 +22,7 @@ import {takeEveryMulticast} from '../utils';
 import {appStateChannel} from '../channels';
 import {listenAppStateChangesSaga} from '../app';
 import {getObjectAttributesSaga} from '../objectAttributes';
+import {getHomePageDataRequest} from 'core/actions';
 
 export function* bootstrapSaga() {
   yield takeEvery(ACTIONS.BOOTSTRAP_REQUEST, function* () {
@@ -31,6 +32,7 @@ export function* bootstrapSaga() {
       );
       const isAuthorized = yield select(selectUserAuthorized);
 
+      yield put(getHomePageDataRequest());
       if (isMyProfileFeatureEnabled) {
         yield call(initUserAuthSaga);
       }

--- a/src/core/sagas/homePage/getHomePageDataSaga.ts
+++ b/src/core/sagas/homePage/getHomePageDataSaga.ts
@@ -1,0 +1,57 @@
+import {all, call, put} from 'redux-saga/effects';
+import {graphQLAPI} from 'api/graphql';
+import {
+  getHomePageDataRequest,
+  refreshHomePageDataRequest,
+} from 'core/actions/home';
+import {RequestError} from 'core/errors';
+import {
+  getCategoriesWithObjects,
+  getObjectByCategories,
+} from 'core/transformators/homePage';
+import type {
+  ListCategoriesResponseDTO,
+  ListShortObjectsResponseDTO,
+} from 'core/types/api';
+import {map} from 'lodash';
+
+export function* getHomePageDataSaga({
+  meta: {failureAction, successAction},
+}: ReturnType<
+  typeof getHomePageDataRequest | typeof refreshHomePageDataRequest
+>) {
+  try {
+    const {items: categoriesListItems}: ListCategoriesResponseDTO = yield call([
+      graphQLAPI,
+      graphQLAPI.getListCategories,
+    ]);
+
+    const categoriesWithObjects: ReturnType<typeof getCategoriesWithObjects> =
+      yield call(getCategoriesWithObjects, categoriesListItems);
+
+    const objectsResponseCollection: Array<ListShortObjectsResponseDTO> =
+      yield all(
+        map(categoriesWithObjects, category => {
+          return call([graphQLAPI, graphQLAPI.getShortObjectList], {
+            categoryId: category.id,
+          });
+        }),
+      );
+
+    const objectsByCategory: ReturnType<typeof getObjectByCategories> =
+      yield call(
+        getObjectByCategories,
+        categoriesWithObjects,
+        objectsResponseCollection,
+      );
+
+    yield put(
+      successAction({
+        categoriesList: categoriesListItems,
+        objectsByCategory: objectsByCategory,
+      }),
+    );
+  } catch (e) {
+    yield put(failureAction(e as RequestError));
+  }
+}

--- a/src/core/sagas/homePage/homePage.ts
+++ b/src/core/sagas/homePage/homePage.ts
@@ -1,0 +1,13 @@
+import {
+  getHomePageDataRequest,
+  refreshHomePageDataRequest,
+} from 'core/actions/home';
+import {takeEvery} from 'redux-saga/effects';
+import {getHomePageDataSaga} from './getHomePageDataSaga';
+
+export function* homePageSaga() {
+  yield takeEvery(
+    [getHomePageDataRequest, refreshHomePageDataRequest],
+    getHomePageDataSaga,
+  );
+}

--- a/src/core/sagas/homePage/index.ts
+++ b/src/core/sagas/homePage/index.ts
@@ -1,0 +1,1 @@
+export {homePageSaga} from './homePage';

--- a/src/core/sagas/index.ts
+++ b/src/core/sagas/index.ts
@@ -8,3 +8,4 @@ export {appSaga} from './app';
 export {visitedObjectsSaga} from './visitedObjects';
 export {getObjectAttributesSaga} from './objectAttributes';
 export {analytics} from './analytics';
+export {homePageSaga} from './homePage';

--- a/src/core/selectors/homePage.ts
+++ b/src/core/selectors/homePage.ts
@@ -1,0 +1,42 @@
+import {IState} from 'core/store';
+import {prepareHomePageData} from 'core/transformators/homePage';
+import {createSelector} from 'reselect';
+import {selectAppLanguage} from './settingsSelectors';
+import {translateAndProcessImagesForEntity} from 'core/transformators/common';
+import {map, mapValues} from 'lodash';
+
+export const selectHomePageRawCategoriesList = (state: IState) =>
+  state.homePage.categoriesList;
+
+export const selectHomePageRawObjectsByCategory = (state: IState) =>
+  state.homePage.objectsByCategory;
+
+export const selectHomePageCategoriesList = createSelector(
+  selectHomePageRawCategoriesList,
+  selectAppLanguage,
+  (categoriesList, locale) => {
+    return map(categoriesList, category => {
+      return translateAndProcessImagesForEntity(category, locale);
+    });
+  },
+);
+
+export const selectHomePageObjectsByCategory = createSelector(
+  selectHomePageRawObjectsByCategory,
+  selectAppLanguage,
+  (objectsByCategory, locale) => {
+    return mapValues(objectsByCategory, values => {
+      return map(values, object =>
+        translateAndProcessImagesForEntity(object, locale),
+      );
+    });
+  },
+);
+
+export const selectHomePageData = createSelector(
+  selectHomePageCategoriesList,
+  selectHomePageObjectsByCategory,
+  (categoriesList, objectsByCategories) => {
+    return prepareHomePageData(categoriesList, objectsByCategories);
+  },
+);

--- a/src/core/selectors/index.ts
+++ b/src/core/selectors/index.ts
@@ -7,3 +7,4 @@ export * from './app';
 export * from './settingsSelectors';
 export * from './favorites';
 export * from './visitedObjects';
+export * from './homePage';

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -14,6 +14,7 @@ import {
   authenticationReducer,
   appConfigurationReducer,
   visitedObjectsReducer,
+  homePageReducer,
 } from './reducers';
 // @ts-ignore
 import {reduxStorage} from 'core/reduxStorage';
@@ -74,6 +75,7 @@ const rootReducer = combineReducers({
     appConfigurationPersistConfig,
     appConfigurationReducer,
   ),
+  homePage: homePageReducer,
 });
 
 const sagaMiddleware = createSagaMiddleware();

--- a/src/core/transformators/common.ts
+++ b/src/core/transformators/common.ts
@@ -1,0 +1,99 @@
+import {
+  CardItem,
+  SupportedLocales,
+  I18nType,
+  ExtractI18nKeys,
+  ObjectShort,
+  CategoryShort,
+} from 'core/types';
+import {compact, find, head, keys, map, omit, pick} from 'lodash';
+import {imagesService} from 'services/ImagesService';
+
+export function convertShortObjectToCardItem(object: ObjectShort): CardItem {
+  return {
+    id: object.id,
+    cover: object.cover,
+    blurhash: object.blurhash,
+    name: object.name,
+    analyticsMetadata: {
+      categoryName: object.category.name,
+      objectName: object.analyticsMetadata.name,
+    },
+  };
+}
+
+export function convertShortCategoryToCardItem(
+  category: CategoryShort,
+): CardItem {
+  return {
+    id: category.id,
+    cover: category.cover,
+    blurhash: category.blurhash,
+    name: category.name,
+    analyticsMetadata: {
+      categoryName: category.analyticsMetadata.name,
+    },
+  };
+}
+
+type WithPropertiesToSanitize<T extends Record<string, any>> = T & {
+  i18n: Array<Partial<I18nType<Extract<keyof T, string>>>>;
+  cover?: string;
+  images?: Array<string>;
+};
+
+export const extractLocaleSpecificValues = <
+  T extends WithPropertiesToSanitize<Record<keyof T, any>>,
+>(
+  entity: T,
+  locale: SupportedLocales | null,
+) => {
+  const firstLocaleSpecificData = omit(head(entity.i18n), ['locale']);
+  const keysToTranslate = keys(firstLocaleSpecificData);
+
+  const localeSpecificData = omit(
+    find(entity.i18n, data => data.locale === locale),
+    ['locale'],
+  );
+
+  const analyticsMetadata = pick(entity, keysToTranslate) as unknown as Record<
+    ExtractI18nKeys<T>,
+    string
+  >;
+
+  return {
+    ...entity,
+    ...localeSpecificData,
+    analyticsMetadata,
+  };
+};
+
+export const processImagesUrls = <
+  T extends WithPropertiesToSanitize<Record<keyof T, any>>,
+>(
+  entity: T,
+) => {
+  return {
+    ...entity,
+    cover: entity.cover
+      ? imagesService.getOriginalImage(entity.cover)
+      : entity.cover,
+    images: entity.images
+      ? compact(map(entity.images, img => imagesService.getOriginalImage(img)))
+      : entity.images,
+  };
+};
+
+export const translateAndProcessImagesForEntity = <
+  T extends WithPropertiesToSanitize<Record<keyof T, any>>,
+>(
+  entity: T,
+  locale: SupportedLocales | null,
+) => {
+  const entityWithEtxtractedLocaleData = extractLocaleSpecificValues(
+    entity,
+    locale,
+  );
+
+  return processImagesUrls(entityWithEtxtractedLocaleData);
+};

--- a/src/core/transformators/homePage.ts
+++ b/src/core/transformators/homePage.ts
@@ -1,6 +1,6 @@
 import {CategoryShort, HomeSectionBarItem, ObjectShort} from 'core/types';
 import {
-  CategoryShortDTO,
+  CategoriesAggregationsByObjectsResponseDTO,
   ListShortObjectsResponseDTO,
   ObjectShortDTO,
 } from 'core/types/api';
@@ -11,36 +11,23 @@ import {
 } from './common';
 
 export function getCategoriesWithObjects(
-  categoriesList: Array<CategoryShortDTO>,
+  categoriesAggreagions: CategoriesAggregationsByObjectsResponseDTO,
 ) {
-  const parentSet = reduce(
-    categoriesList,
-    (acc, category) => {
-      if (category.parent) {
-        acc.add(category.parent);
-      }
-      return acc;
-    },
-    new Set<string>(),
-  );
-
-  return filter(categoriesList, category => {
-    return !parentSet.has(category.id);
-  });
+  return filter(categoriesAggreagions, category => category.doc_count !== 0);
 }
 
 export function getObjectByCategories(
-  categoriesList: Array<CategoryShortDTO>,
+  categoriesAggreagions: CategoriesAggregationsByObjectsResponseDTO,
   objectsCollectionResponse: Array<ListShortObjectsResponseDTO>,
 ) {
   const objectsCollection = map(objectsCollectionResponse, 'items');
   return reduce(
-    categoriesList,
+    categoriesAggreagions,
     (acc, category, index) => {
       const objects = objectsCollection[index];
 
       if (objects) {
-        acc[category.id] = objects;
+        acc[category.key] = objects;
       }
 
       return acc;

--- a/src/core/transformators/homePage.ts
+++ b/src/core/transformators/homePage.ts
@@ -1,0 +1,97 @@
+import {CategoryShort, HomeSectionBarItem, ObjectShort} from 'core/types';
+import {
+  CategoryShortDTO,
+  ListShortObjectsResponseDTO,
+  ObjectShortDTO,
+} from 'core/types/api';
+import {filter, groupBy, isEmpty, map, orderBy, reduce} from 'lodash';
+import {
+  convertShortCategoryToCardItem,
+  convertShortObjectToCardItem,
+} from './common';
+
+export function getCategoriesWithObjects(
+  categoriesList: Array<CategoryShortDTO>,
+) {
+  const parentSet = reduce(
+    categoriesList,
+    (acc, category) => {
+      if (category.parent) {
+        acc.add(category.parent);
+      }
+      return acc;
+    },
+    new Set<string>(),
+  );
+
+  return filter(categoriesList, category => {
+    return !parentSet.has(category.id);
+  });
+}
+
+export function getObjectByCategories(
+  categoriesList: Array<CategoryShortDTO>,
+  objectsCollectionResponse: Array<ListShortObjectsResponseDTO>,
+) {
+  const objectsCollection = map(objectsCollectionResponse, 'items');
+  return reduce(
+    categoriesList,
+    (acc, category, index) => {
+      const objects = objectsCollection[index];
+
+      if (objects) {
+        acc[category.id] = objects;
+      }
+
+      return acc;
+    },
+    {} as Record<string, Array<ObjectShortDTO>>,
+  );
+}
+
+export function prepareHomePageData(
+  categoriesList: Array<CategoryShort>,
+  objectsByCategories: Record<string, Array<ObjectShort>>,
+) {
+  const sortedCategories = orderBy(categoriesList, ['index'], ['asc']);
+
+  const {null: parentCategories, ...subcategoriesMap} = groupBy(
+    sortedCategories,
+    'parent',
+  );
+
+  return reduce(
+    parentCategories,
+    (acc, category) => {
+      let objects = objectsByCategories[category.id];
+
+      if (objects?.length && !category.parent) {
+        acc.push({
+          title: category.name,
+          items: map(objects, convertShortObjectToCardItem),
+          isCategoryItems: false,
+          categoryId: category.id,
+        });
+      } else {
+        const subCategories = subcategoriesMap[category.id];
+        const subCategoriesWithObjects = filter(subCategories, subCategory => {
+          return !isEmpty(objectsByCategories[subCategory.id]);
+        });
+        if (subCategoriesWithObjects?.length) {
+          acc.push({
+            title: category.name,
+            items: map(
+              subCategoriesWithObjects,
+              convertShortCategoryToCardItem,
+            ),
+            isCategoryItems: true,
+            categoryId: category.id,
+          });
+        }
+      }
+
+      return acc;
+    },
+    [] as Array<HomeSectionBarItem>,
+  );
+}

--- a/src/core/types/api/graphql.ts
+++ b/src/core/types/api/graphql.ts
@@ -32,6 +32,11 @@ export interface ObjectShortDTO {
   categoryId: string;
 }
 
+export interface CategoryAggregationsByObjectsDTO {
+  doc_count: number;
+  key: string;
+}
+
 export interface ListCategoriesResponseDTO {
   items: Array<CategoryShortDTO>;
 }
@@ -39,3 +44,6 @@ export interface ListCategoriesResponseDTO {
 export interface ListShortObjectsResponseDTO {
   items: Array<ObjectShortDTO>;
 }
+
+export type CategoriesAggregationsByObjectsResponseDTO =
+  Array<CategoryAggregationsByObjectsDTO>;

--- a/src/core/types/api/graphql.ts
+++ b/src/core/types/api/graphql.ts
@@ -15,7 +15,7 @@ export interface CategoryShortDTO {
   name: string;
   id: string;
   parent: string | null;
-  blurhash: string;
+  blurhash: string | null;
   index: number;
   owner: string | null;
 }
@@ -28,7 +28,7 @@ export interface ObjectShortDTO {
   i18n: Array<I18nType<'name'>>;
   name: string;
   id: string;
-  blurhash: string;
+  blurhash: string | null;
   categoryId: string;
 }
 

--- a/src/core/types/api/graphql.ts
+++ b/src/core/types/api/graphql.ts
@@ -1,0 +1,41 @@
+interface DefaultI18n {
+  locale: string;
+}
+export type I18nType<T extends string> = {
+  [key in T]: string | null;
+} & DefaultI18n;
+
+export type ExtractI18nKeys<T> = {
+  [K in keyof T]: T[K] extends Array<I18nType<infer R>> ? R : never;
+}[keyof T];
+
+export interface CategoryShortDTO {
+  cover: string;
+  i18n: Array<I18nType<'name'>>;
+  name: string;
+  id: string;
+  parent: string | null;
+  blurhash: string;
+  index: number;
+  owner: string | null;
+}
+
+export interface ObjectShortDTO {
+  cover: string;
+  category: {
+    name: string;
+  };
+  i18n: Array<I18nType<'name'>>;
+  name: string;
+  id: string;
+  blurhash: string;
+  categoryId: string;
+}
+
+export interface ListCategoriesResponseDTO {
+  items: Array<CategoryShortDTO>;
+}
+
+export interface ListShortObjectsResponseDTO {
+  items: Array<ObjectShortDTO>;
+}

--- a/src/core/types/api/index.ts
+++ b/src/core/types/api/index.ts
@@ -1,0 +1,1 @@
+export * from './graphql';

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -2,6 +2,7 @@ import {MultiPolygon, LineString} from '@turf/helpers';
 import {IRequestError} from './errors';
 import {animations} from 'assets';
 import {ObjectField} from 'core/constants';
+import {CategoryShortDTO, ExtractI18nKeys, ObjectShortDTO} from './api';
 
 export interface ILabelError {
   text: string;
@@ -221,6 +222,24 @@ export type SpotI18n =
     } | null)[]
   | null
   | undefined;
+
+export interface CategoryShort extends CategoryShortDTO {
+  analyticsMetadata: Record<ExtractI18nKeys<ObjectShortDTO>, string>;
+}
+
+export interface ObjectShort extends ObjectShortDTO {
+  analyticsMetadata: Record<ExtractI18nKeys<ObjectShortDTO>, string>;
+}
+export interface CardItem {
+  name: string;
+  cover: string;
+  blurhash: string;
+  id: string;
+  analyticsMetadata: {
+    categoryName: string;
+    objectName?: string;
+  };
+}
 
 export enum TestIDs {
   TabBarItemMain = 'tabBarItemMain',

--- a/src/core/types/homePage.ts
+++ b/src/core/types/homePage.ts
@@ -1,0 +1,8 @@
+import {CardItem} from './common';
+
+export type HomeSectionBarItem = {
+  title: string;
+  items: Array<CardItem>;
+  isCategoryItems: boolean;
+  categoryId: string;
+};

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -8,3 +8,5 @@ export * from './favorites';
 export * from './app';
 export * from './visitedObjects';
 export * from './analytics';
+export * from './homePage';
+export * from './api';

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {RefreshPageReminder, SuspenseView, SnackBar} from 'atoms';
+import {SuspenseView, SnackBar} from 'atoms';
 import {HomeSectionBar} from 'organisms';
 import {FlatList, RefreshControl, View} from 'react-native';
 
@@ -15,11 +15,9 @@ export const Home = () => {
   const styles = useThemeStyles(themeStyles);
   const {
     loading,
-    error,
+    errorTexts,
     listRef,
-    getInitialData,
     refreshing,
-    getData,
     navigateToObjectDetails,
     onCategoryPress,
     onAllObjectsPress,
@@ -27,8 +25,8 @@ export const Home = () => {
     sendIsFavoriteChangedEvent,
     homeData,
     theme,
-    isFocused,
-    isUpdatesAvailable,
+    getHomePageData,
+    refreshHomePageData,
     snackBarProps,
   } = useHome();
 
@@ -36,8 +34,8 @@ export const Home = () => {
     <View style={styles.container}>
       <SuspenseView
         loading={loading}
-        error={homeData ? null : error}
-        retryCallback={getInitialData}>
+        error={homeData ? null : errorTexts}
+        retryCallback={getHomePageData}>
         <FlatList
           ref={listRef}
           style={styles.list}
@@ -47,8 +45,8 @@ export const Home = () => {
             <RefreshControl
               tintColor={theme === 'light' ? COLORS.forestGreen : COLORS.white}
               colors={[COLORS.forestGreen]}
-              refreshing={refreshing && isFocused}
-              onRefresh={getData}
+              refreshing={refreshing}
+              onRefresh={refreshHomePageData}
             />
           }
           data={homeData}
@@ -65,7 +63,7 @@ export const Home = () => {
             />
           )}
         />
-        {isUpdatesAvailable ? <RefreshPageReminder onPress={getData} /> : null}
+        {/* {isUpdatesAvailable ? <RefreshPageReminder onPress={getData} /> : null} */}
         <SnackBar isOnTop {...snackBarProps} />
       </SuspenseView>
     </View>

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -34,7 +34,7 @@ export const Home = () => {
     <View style={styles.container}>
       <SuspenseView
         loading={loading}
-        error={homeData ? null : errorTexts}
+        error={errorTexts}
         retryCallback={getHomePageData}>
         <FlatList
           ref={listRef}

--- a/src/screens/Home/hooks/useHome.tsx
+++ b/src/screens/Home/hooks/useHome.tsx
@@ -32,7 +32,6 @@ export const useHome = () => {
 
   const {loading} = useRequestLoading(getHomePageDataRequest);
   const {errorTexts} = useOnRequestError(getHomePageDataRequest, '');
-
   const {loading: refreshing} = useRequestLoading(refreshHomePageDataRequest);
 
   const getHomePageData = useCallback(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,6 +4941,16 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.2.1.tgz#9403f51c17cae37edf870c6bc0c81c1ece5ccef8"
   integrity sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==
 
+"@reduxjs/toolkit@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.5.tgz#c0d2d8482ef80722bebe015ff05b06c34bfb6e0d"
+  integrity sha512-aeFA/s5NCG7NoJe/MhmwREJxRkDs0ZaSqt0MxhWUrwCf1UQXpwR87RROJEql0uAkLI6U7snBOYOcKw83ew3FPg==
+  dependencies:
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
+
 "@rnmapbox/maps@^10.1.23":
   version "10.1.24"
   resolved "https://registry.yarnpkg.com/@rnmapbox/maps/-/maps-10.1.24.tgz#9f9c2d9df96a900d5eb4de012509084135d13574"
@@ -9925,6 +9935,11 @@ immer@9.0.6:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
   integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
+immer@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -13816,7 +13831,12 @@ redux-saga@1.3.0:
   dependencies:
     "@redux-saga/core" "^1.3.0"
 
-redux@5.0.1:
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
+
+redux@5.0.1, redux@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
   integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
@@ -13973,6 +13993,11 @@ reselect@^4.0.0:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
+reselect@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### What does this PR do:

Migrates Home Page from fetching data from index file to GraphQL approach.

1) Added queries to fetch all categories and related objects
2) Added new **createAsyncAction** function to reduce redux boilerplate
3) Added **redux/toolkit** to get rid typesafe action lib
4) Added actions folder. Actions will be removed from reducers with new approach

#### Visual change
No changes

#### Ticket Links:
[<!-- Link to the ticket in GitHub -->](https://jira.epam.com/jira/browse/EPMEDUGRN-799)

