### PR TITLE
fix(825): fixed OneTimeCode for Android

### DIFF
--- a/src/components/atoms/OneTimeCode/styles.ts
+++ b/src/components/atoms/OneTimeCode/styles.ts
@@ -56,8 +56,8 @@ export const themeStyles = {
   },
   hiddenCodeInput: {
     position: 'absolute',
-    height: 0,
-    width: 0,
+    height: 1,
+    width: 1,
     opacity: 0,
   },
 };


### PR DESCRIPTION
### What does this PR do:

Android: when width and height are set to 0, TextInput works unexpectedly (calls onBlur right after codeRef?.current?.focus(); and doesn't focus & show input value on subsequent field taps/interactions).

