### PR TITLE
fix(860): make the Google rating filter fit the screen

### DIFF
--- a/src/components/atoms/Multiswitch/styles.ts
+++ b/src/components/atoms/Multiswitch/styles.ts
@@ -6,20 +6,20 @@ export const styles = createThemeStyles({
     flexDirection: 'row',
     paddingVertical: 4,
     borderRadius: 12,
-    justifyContent: 'center',
+    justifyContent: 'space-between',
+    flex: 1,
   },
   mainContainer: {
     flex: 1,
   },
   item: {
     height: 40,
-    minWidth: 84,
-    paddingHorizontal: 25,
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: 12,
+    flex: 1,
   },
   text: {
-    ...FONTS_PRESETS.footnoteBold,
+    ...FONTS_PRESETS.footnoteBold, 
   },
 });


### PR DESCRIPTION
### What does this PR do:

Fix Google rating filter by updating ratings items layout, so now each item has the same size

#### Visual change - screenshot before:
<img width="378" alt="image" src="https://github.com/user-attachments/assets/bf89eafa-d9df-4a18-a972-75c0f900d7a1">


#### Visual change - screenshot after:
![image](https://github.com/user-attachments/assets/bbe90889-8f10-4c5b-9df0-8c4ee2788d76)


#### Ticket Links:
https://jira.epam.com/jira/browse/EPMEDUGRN-860