### PR TITLE
fix(868): fix bug with settlements list is not displayed in alphabetic order

### DIFF
--- a/src/core/transformators/settlements.ts
+++ b/src/core/transformators/settlements.ts
@@ -1,5 +1,5 @@
 import {SpotItemDTO} from 'core/types';
-import {reduce, chain, includes, toLower} from 'lodash';
+import {reduce, chain, includes, toLower, orderBy} from 'lodash';
 
 export function prepareSettlementsSections(
   settlements: SpotItemDTO[],
@@ -7,7 +7,7 @@ export function prepareSettlementsSections(
   searchValue: string,
 ) {
   const sections = reduce(
-    settlements,
+    orderBy(settlements, 'value'),
     (acc, item) => {
       if (
         includes(regionsToInclude, item.id) &&


### PR DESCRIPTION

### What does this PR do:

Fix for the settlements list is not displayed in alphabetic order in EN

#### Visual change - screenshot before:

<details>
</details>

#### Visual change - screenshot after:

<details>
https://github.com/user-attachments/assets/77887ff6-c315-48d1-826d-1b6e69a626bd
</details>

#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-868

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA
