### PR TITLE
fix(874): hide apply button after opening keyboard on settlements screen

### DIFF
--- a/src/screens/Settlements/Settlements.tsx
+++ b/src/screens/Settlements/Settlements.tsx
@@ -1,5 +1,11 @@
 import React, {useCallback, useEffect} from 'react';
-import {Text, TouchableOpacity, View} from 'react-native';
+import {
+  Text,
+  TouchableOpacity,
+  View,
+  Platform,
+  KeyboardAvoidingView,
+} from 'react-native';
 import {HighlightedText, SnackBar, SuspenseView} from 'atoms';
 import {useThemeStyles, useTranslation} from 'core/hooks';
 import {screenOptions} from './screenOptions';
@@ -89,7 +95,10 @@ export const Settlements = () => {
   }, [navigation, renderHeaderRight]);
 
   return (
-    <View style={styles.container}>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={24}
+      style={styles.container}>
       <SearchField
         testID={'searchField'}
         onChange={handleSearchValue}
@@ -140,7 +149,7 @@ export const Settlements = () => {
         />
       </SuspenseView>
       <SnackBar isOnTop testID="snackBar" {...snackBarProps} />
-    </View>
+    </KeyboardAvoidingView>
   );
 };
 


### PR DESCRIPTION
### What does this PR do:

Hide apply button after opening keyboard on settlements screen

#### Visual change - screenshot before:

NA

#### Visual change - screenshot after:

<details>

https://github.com/user-attachments/assets/3bff8afe-2aa0-4e63-a05a-1f3550a6d231

</details>

#### Ticket Links:

https://jira.epam.com/jira/browse/EPMEDUGRN-874

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?

NA