### PR TITLE
Fix/917 'Settlements' option in Filters is displayed not in bold as designed

### DIFF
--- a/src/components/molecules/FiltersSectionContainer/styles.ts
+++ b/src/components/molecules/FiltersSectionContainer/styles.ts
@@ -22,7 +22,7 @@ export const themeStyles = createThemeStyles({
     marginBottom: 4,
   },
   subSectionName: {
-    ...FONTS_PRESETS.subheadlineRegular,
+    ...FONTS_PRESETS.subheadlineBold,
     paddingVertical: 8,
     color: {
       light: COLORS.light.text.primary,


### PR DESCRIPTION
### What does this PR do:

Fix bug with 'Settlements' option in Filters is displayed not in bold as designed

#### Visual change - screenshot before:

<details>
<img width="375" alt="Снимок экрана 2024-10-19 в 10 09 45" src="https://github.com/user-attachments/assets/aa12a318-f074-4c41-a49f-80b153b99edd">
</details>


#### Visual change - screenshot after:

<details>
<img width="375" alt="Снимок экрана 2024-10-19 в 10 02 53" src="https://github.com/user-attachments/assets/ceacb3c1-383d-4da4-8224-3dbfefac0634">
</details>

#### Ticket Links:

https://jiraeu.epam.com/browse/EPMEDUGRN-917

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
