### PR TITLE
Fix/915 The empty space under the Search bar appears when a user unselects chosen options

### DIFF
--- a/src/screens/Settlements/Settlements.tsx
+++ b/src/screens/Settlements/Settlements.tsx
@@ -133,7 +133,10 @@ export const Settlements = () => {
             sections={settlementsSections}
             keyExtractor={item => item.id}
             stickySectionHeadersEnabled={false}
-            maintainVisibleContentPosition={{minIndexForVisible: 1}}
+            maintainVisibleContentPosition={{
+              minIndexForVisible: 1,
+              autoscrollToTopThreshold: 1,
+            }}
             getItemLayout={getItemLayout}
             renderItem={({item}) => (
               <ListItem


### PR DESCRIPTION
### What does this PR do:

Fix bug with the empty space under the Search bar appears when a user unselects chosen options

#### Visual change - screenshot before:

<details>

https://github.com/user-attachments/assets/4990f269-9df7-4601-af21-c30602eddc0a

</details>

#### Visual change - screenshot after:

<details>

https://github.com/user-attachments/assets/8206dc3b-28d0-41f0-b1d8-6b0e029df59a

</details>

#### Ticket Links:

https://jiraeu.epam.com/browse/EPMEDUGRN-915

#### Related PR(s):

NA

#### Any of `check_pr_for_aws_creds` failed. What to do?
It means AWS credentials leaked.
Please adhere to [these steps](https://github.com/radzima-green-travel/green-travel-combine/wiki/AWS-credentials-leaked.-What-to-do%3F).
