### PR TITLE
fix(906): fix configuration for expo prod build

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,6 +19,9 @@
           "resizeMode": "cover",
           "backgroundColor": "#1F1F1F"
         }
+      },
+      "config": {
+        "usesNonExemptEncryption": false
       }
     },
     "androidStatusBar": {

--- a/eas.json
+++ b/eas.json
@@ -15,7 +15,7 @@
     },
     "production": {
       "credentialsSource": "local",
-      "distribution": "internal"
+      "distribution": "store"
     }
   },
   "submit": {


### PR DESCRIPTION
### What does this PR do:

1. Changed distribution from internal to store for the prod build;
2. Added usesNonExemptEncryption false into iOS config to avoid adding encryption type each type the build is deployed. Since we don't use custom encryption, we must set it to false.
