### PR TITLE
fix(939): added custom plugin to fix mailto and tel links for Android

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,5 @@
 import withRemoveiOSNotificationEntitlement from './config-plugins/withRemoveiOSNotificationEntitlement';
+import withAndroidQueries from './config-plugins/withAndroidQueries';
 
 type Dict = {[key: string]: any};
 export default ({config}: Dict) => {
@@ -54,6 +55,7 @@ export default ({config}: Dict) => {
     },
     plugins: [
       ...(config.plugins ?? []),
+      [withAndroidQueries],
       [withRemoveiOSNotificationEntitlement],
       [
         '@rnmapbox/maps',

--- a/config-plugins/withAndroidQueries.js
+++ b/config-plugins/withAndroidQueries.js
@@ -1,0 +1,23 @@
+const withAndroidManifest = require('@expo/config-plugins').withAndroidManifest;
+
+const withAndroidQueries = config => {
+  return withAndroidManifest(config, mod => {
+    mod.modResults.manifest.queries = [
+      {
+        intent: [
+          {
+            action: [{$: {'android:name': 'android.intent.action.SENDTO'}}],
+            data: [{$: {'android:scheme': 'mailto'}}],
+          },
+          {
+            action: [{$: {'android:name': 'android.intent.action.DIAL'}}],
+          },
+        ],
+      },
+    ];
+
+    return mod;
+  });
+};
+
+module.exports = withAndroidQueries;


### PR DESCRIPTION
### What does this PR do:

As per [expo documentation](https://docs.expo.dev/linking/into-other-apps/#specify-android-intents-to-handle-common-url), for Android 11 (API level 30) and above we have to specify the intents your app will handle in the AndroidManifest.xml file.

Added a custom plugin according to the docs. It fixes the navigation issue for mailto and tel links.

