### PR TITLE
fix(938): fix text zoom in a web view for Android

### DIFF
--- a/src/screens/InAppWebView/InAppWebView.tsx
+++ b/src/screens/InAppWebView/InAppWebView.tsx
@@ -30,6 +30,7 @@ export const InAppWebView = () => {
         onNavigationStateChange={event => {
           setLoading(event.loading);
         }}
+        textZoom={100}
         source={{uri: url}}
         originWhitelist={['*']}
         viewportContent={'width=device-width, user-scalable=no'}


### PR DESCRIPTION
### What does this PR do:

As per [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#textzoom):
If the user has set a custom font size in the Android system, an undesirable scale of the site interface in WebView occurs.
When setting the standard textZoom (100) parameter size, this undesirable effect disappears.

#### Visual change - screenshot before:
![Screenshot_1731518386](https://github.com/user-attachments/assets/0acdfade-96f7-45b0-a7fb-2e9cdcf99c10)

#### Visual change - screenshot after:
![Screenshot_1731518370](https://github.com/user-attachments/assets/d75be718-5185-4b0c-8cb6-c6937036956d)

