### PR TITLE
fix(934): clear filter button is enabled when only hide visited filter is on

### DIFF
--- a/src/core/transformators/filters.ts
+++ b/src/core/transformators/filters.ts
@@ -86,7 +86,8 @@ export const checkIfFiltersAreUnset = (filters?: SearchFilters) => {
       !filters.googleRating.length &&
       !filters.municipalities.length &&
       !filters.regions.length &&
-      !filters.distance.isOn)
+      !filters.distance.isOn &&
+      !filters.excludeVisited)
   );
 };
 


### PR DESCRIPTION
### What does this PR do:

Update checkIfFiltersAreUnset trabformator

#### Ticket Links:
[EPMEDUGRN-934](https://jiraeu.epam.com/browse/EPMEDUGRN-934)