### PR TITLE
fix(923): fix bug with returning distance filter value to default value

### DIFF
--- a/src/components/molecules/FilterDistance/FilterDistance.tsx
+++ b/src/components/molecules/FilterDistance/FilterDistance.tsx
@@ -1,5 +1,5 @@
 import {CustomSlider} from 'components/atoms';
-import React, {memo, useState} from 'react';
+import React, {memo, useEffect, useState} from 'react';
 import {Text, View} from 'react-native';
 import {themeStyles} from './styles';
 import {ListItem} from 'components/molecules';
@@ -17,6 +17,10 @@ export const FilterDistance = memo(
     const styles = useThemeStyles(themeStyles);
     const {t} = useTranslation('filters');
     const [distanceValue, setDistanceValue] = useState(distance);
+
+    useEffect(() => {
+      setDistanceValue(distance);
+    }, [distance]);
 
     return (
       <View>


### PR DESCRIPTION
#### Ticket Links:
[[EPMEDUGRN-951] The 'Consider the distance' km value returns to default number when a user comes back to the filters from results screen](https://jiraeu.epam.com/browse/EPMEDUGRN-951)